### PR TITLE
Issue 5: floating point in equality comparison commands.c

### DIFF
--- a/mcp/CMakeLists.txt
+++ b/mcp/CMakeLists.txt
@@ -41,6 +41,38 @@ if (NO_KIDS_TEST)
     add_definitions(-DNO_KIDS_TEST)
 endif(NO_KIDS_TEST)
 
+# Do NOT enable building unit tests if you use "vanilla" debian 'jessie'.
+#
+# Building unit tests requires cmake>=3.5.0 to build cmocka's>=1.1.5 necessary
+# to run the tests. 'jessie' comes with cmake=3.0.2 and cmocka=0.4.1 which API
+# in incompatible with the newer version.
+#
+# If you want to build the tests, install cmake 3.5.0 from 'jessie-backports'
+# repository. Follow the link below for more information:
+#
+#   https://www.lucas-nussbaum.net/blog/?p=947
+#
+# tl;dr Add these line to your /etc/apt/sources.list
+#
+#   deb http://archive.debian.org/debian/ jessie-backports main contrib non-free
+#
+# and run the commands below afterwards
+#
+#   sudo sh -c "echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until"
+#   sudo apt update
+option(ENABLE_TESTING "build unit tests" OFF)
+if (ENABLE_TESTING)
+    include(ExternalProject)
+    ExternalProject_Add(libcmocka
+        GIT_REPOSITORY https://gitlab.com/cmocka/cmocka
+        GIT_TAG cmocka-1.1.5
+        CMAKE_ARGS
+            -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+            -DCMAKE_BUILD_TYPE:STRING=Release
+    )
+    enable_testing()
+endif(ENABLE_TESTING)
+
 SET (CMAKE_C_FLAGS                  "-Wall -std=gnu99 -mcx16")
 SET (CMAKE_C_FLAGS_DEBUG            "-O0 -fno-omit-frame-pointer -ggdb")
 SET (CMAKE_C_FLAGS_MINSIZEREL       "-Os -DNDEBUG")
@@ -298,6 +330,7 @@ set(SYNCLINK_DIR "${PROJECT_SOURCE_DIR}/../external_libs/synclink")
 set(COMMUNICATIONS_DIR "${PROJECT_SOURCE_DIR}/communications/")
 set(SOCAT_DIR "${PROJECT_SOURCE_DIR}/../external_libs/socat")
 set(LIBLINKLIST_DIR "${PROJECT_SOURCE_DIR}/../liblinklist")
+set(UTILS_DIR "${PROJECT_SOURCE_DIR}/../utils")
 
 set(ETC_DIR "${PROJECT_SOURCE_DIR}/../blast_etc")
 FILE(GLOB etc_files "${ETC_DIR}/*.txt" "${ETC_DIR}/*.sch" "${ETC_DIR}/*.library" "${ETC_DIR}/*.lut" "${ETC_DIR}/WMM.COF")
@@ -356,6 +389,9 @@ add_subdirectory(${SOCAT_DIR} "${PROJECT_BINARY_DIR}/socat")
 # add common linklist objects
 add_subdirectory(${LIBLINKLIST_DIR} "${PROJECT_BINARY_DIR}/liblinklist")
 
+# add utils objects
+add_subdirectory(${UTILS_DIR} "${PROJECT_BINARY_DIR}/utils")
+
 add_library (pointing OBJECT ${POINTING_SRCS} ${POINTING_HEADERS})
 define_file_basename_for_sources(pointing)
 add_library (motors OBJECT ${MOTOR_SRCS} ${MOTOR_HEADERS})
@@ -413,7 +449,8 @@ add_executable (mcp
     $<TARGET_OBJECTS:roach>
     $<TARGET_OBJECTS:liblinklist>
     $<TARGET_OBJECTS:mcp_obj>
-    ) 
+    $<TARGET_OBJECTS:utils>
+)
 
 add_dependencies(mcp soem phenomproj)
 

--- a/mcp/CMakeLists.txt
+++ b/mcp/CMakeLists.txt
@@ -344,6 +344,7 @@ include_directories (
     "${MPSSE_DIR}"
     "${SYNCLINK_DIR}"
     "${LIBLINKLIST_DIR}"
+    "${UTILS_DIR}/include"
     )
 
 # add commanding objects

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(utils OBJECT
+    comparison.c
+)
+target_include_directories(utils PUBLIC .)
+
+if (ENABLE_TESTING)
+    add_subdirectory(tests)
+endif(ENABLE_TESTING)

--- a/utils/comparison.c
+++ b/utils/comparison.c
@@ -2,9 +2,7 @@
  * @file utils.c
  * @brief Definitions of general utility functions.
  */
-#include <limits.h>
 #include <math.h>
-#include <string.h>
 #include <stdlib.h>
 #include "include/comparison.h"
 

--- a/utils/comparison.c
+++ b/utils/comparison.c
@@ -7,7 +7,7 @@
 #include "include/comparison.h"
 
 
-int relatively_equal(double a, double b, double maxrelerr)
+int is_relatively_equal(double a, double b, double maxrelerr)
 {
     if (a == b)
         return 1;
@@ -21,7 +21,7 @@ int relatively_equal(double a, double b, double maxrelerr)
     return 0;
 }
 
-int almost_equal(double a, double b, int maxulps)
+int is_almost_equal(double a, double b, const int maxulps)
 {
     if (a == b)
         return 1;

--- a/utils/comparison.c
+++ b/utils/comparison.c
@@ -1,0 +1,30 @@
+/**
+ * @file utils.c
+ * @brief Definitions of general utility functions.
+ */
+#include <limits.h>
+#include <math.h>
+#include <string.h>
+#include <stdlib.h>
+#include "include/comparison.h"
+
+
+int relatively_equal(double a, double b, double maxrelerr)
+{
+    if (a == b)
+        return 1;
+    double relerr = fabs(b) > fabs(a) ? fabs((a - b) / b) : fabs((a - b) / a);
+    if (relerr <= maxrelerr)
+        return 1;
+    return 0;
+}
+
+int almost_equal(double a, double b, int maxulps)
+{
+    if (a == b)
+        return 1;
+    int idiff = abs(*((int *) &a) - *((int *) &b))
+    if (idiff <= maxulps)
+        return 1;
+    return 0;
+}

--- a/utils/comparison.c
+++ b/utils/comparison.c
@@ -11,6 +11,10 @@ int relatively_equal(double a, double b, double maxrelerr)
 {
     if (a == b)
         return 1;
+    if (isnan(a) || isnan(b))
+        return 0;
+    if (isinf(a) || isinf(b))
+        return 0;
     double relerr = fabs(b) > fabs(a) ? fabs((a - b) / b) : fabs((a - b) / a);
     if (relerr <= maxrelerr)
         return 1;
@@ -21,7 +25,11 @@ int almost_equal(double a, double b, int maxulps)
 {
     if (a == b)
         return 1;
-    int idiff = abs(*((int *) &a) - *((int *) &b))
+    if (isnan(a) || isnan(b))
+        return 0;
+    if (isinf(a) || isinf(b))
+        return 0;
+    int idiff = abs(*((int *) &a) - *((int *) &b));
     if (idiff <= maxulps)
         return 1;
     return 0;

--- a/utils/include/comparison.h
+++ b/utils/include/comparison.h
@@ -1,0 +1,50 @@
+/**
+ * @file utils.h
+ * @brief General utility functions.
+ */
+#ifndef TIMFLIGHT_UTILS_COMPARISON_H
+#define TIMFLIGHT_UTILS_COMPARISON_H
+
+/**
+ * @fn int relatively_equal(double a, double b, double maxreldiff)
+ * @brief Safely compares floating-point numbers.
+ *
+ * Function compares two floating-point numbers by calculating their relative
+ * difference. If the relative difference is less than the given threshold,
+ * the numbers are considered to be the same.
+ *
+ * @param x the first number to compare
+ * @param y the second number to compare
+ * @param reldiff maximal relative difference between two (almost) equal numbers
+ * @return a positive integer if numbers are equal, 0 otherwise
+ *
+ * @note More information regarding comparing floating-point numbers
+ * accurately can be found at the following websites:
+ *   - <a href="https://floating-point-gui.de/"></a>
+ *   - <a href=https://bitbashing.io/comparing-floats.html"></a>
+ */
+int relatively_equal(double a, double b, double maxreldiff);
+
+/**
+ * @fn int almost_equal(double a, double b, int maxulps)
+ * @brief Safely compares floating-point numbers.
+ *
+ * Function compares two floating-point numbers by measuring their mutual
+ * distance in the units of the least precision (ULP). Numbers whose mutual
+ * distance is less than the provided threshold are considered to be the same.
+ *
+ * The threshold should be a small, positive integer.
+ *
+ * @param a the first number to compare
+ * @param b the second number to compare
+ * @param maxulps maximal distance between two (almost) equal numbers
+ * @return a postive integer if numbers are equal, 0 otherwise
+ *
+ * @note More information regarding comparing floating-point numbers
+ * accurately can be found at the following websites:
+ *   - <a href=https://bitbashing.io/comparing-floats.html">this</a>
+ *   - <a href="https://floating-point-gui.de/"></a>
+ */
+int almost_equal(double a, double b, int maxulps);
+
+#endif /* TIMFLIGHT_UTILS_COMPARISON_H */

--- a/utils/include/comparison.h
+++ b/utils/include/comparison.h
@@ -6,7 +6,7 @@
 #define TIMFLIGHT_UTILS_COMPARISON_H
 
 /**
- * @fn int relatively_equal(double a, double b, double maxreldiff)
+ * @fn int is_relatively_equal(double a, double b, double maxreldiff)
  * @brief Safely compares floating-point numbers.
  *
  * Function compares two floating-point numbers by calculating their relative
@@ -26,7 +26,7 @@
 int relatively_equal(double a, double b, double maxreldiff);
 
 /**
- * @fn int almost_equal(double a, double b, int maxulps)
+ * @fn int is_almost_equal(double a, double b, int maxulps)
  * @brief Safely compares floating-point numbers.
  *
  * Function compares two floating-point numbers by measuring their mutual

--- a/utils/include/comparison.h
+++ b/utils/include/comparison.h
@@ -6,6 +6,18 @@
 #define TIMFLIGHT_UTILS_COMPARISON_H
 
 /**
+ * @def DEFAULT_MAXRELDIFF
+ * @brief Default maximal relative difference.
+ */
+#define DEFAULT_MAXRELDIFF 1.0e-06
+
+/**
+ * @def DEFAULT_MAXULPS
+ * @brief Default maximal distance in units of the least precision (ULPS).
+ */
+#define DEFAULT_MAXULPS 3
+
+/**
  * @fn int is_relatively_equal(double a, double b, double maxreldiff)
  * @brief Safely compares floating-point numbers.
  *

--- a/utils/include/comparison.h
+++ b/utils/include/comparison.h
@@ -23,7 +23,7 @@
  *   - <a href="https://floating-point-gui.de/"></a>
  *   - <a href=https://bitbashing.io/comparing-floats.html"></a>
  */
-int relatively_equal(double a, double b, double maxreldiff);
+int is_relatively_equal(double a, double b, double maxreldiff);
 
 /**
  * @fn int is_almost_equal(double a, double b, int maxulps)
@@ -42,9 +42,9 @@ int relatively_equal(double a, double b, double maxreldiff);
  *
  * @note More information regarding comparing floating-point numbers
  * accurately can be found at the following websites:
- *   - <a href=https://bitbashing.io/comparing-floats.html">this</a>
+ *   - <a href=https://bitbashing.io/comparing-floats.html"></a>
  *   - <a href="https://floating-point-gui.de/"></a>
  */
-int almost_equal(double a, double b, int maxulps);
+int is_almost_equal(double a, double b, int maxulps);
 
 #endif /* TIMFLIGHT_UTILS_COMPARISON_H */

--- a/utils/tests/CMakeLists.txt
+++ b/utils/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.23)
+
+project(test_utils C)
+
+include(CTest)
+
+add_executable(${PROJECT_NAME}
+               test_comparison.c ../comparison.c
+              )
+target_link_libraries(${PROJECT_NAME} m cmocka)
+target_include_directories(${PROJECT_NAME} PRIVATE
+                           ${CMOCKA_PUBLIC_INCLUDE_DIRS}
+                           ../include
+                           )
+add_test(NAME utils COMMAND ${PROJECT_NAME})

--- a/utils/tests/CMakeLists.txt
+++ b/utils/tests/CMakeLists.txt
@@ -1,15 +1,16 @@
-cmake_minimum_required(VERSION 3.23)
+find_package(cmocka)
 
-project(test_utils C)
+add_executable(test_utils
+        test_comparison.c
+        "$<TARGET_OBJECTS:utils>"
+)
+target_include_directories(test_utils PRIVATE
+        ${CMOCKA_INCLUDE_DIR}
+        ../include
+)
+target_link_libraries(test_utils
+        m
+        ${CMOCKA_LIBRARY}
+)
 
-include(CTest)
-
-add_executable(${PROJECT_NAME}
-               test_comparison.c ../comparison.c
-              )
-target_link_libraries(${PROJECT_NAME} m cmocka)
-target_include_directories(${PROJECT_NAME} PRIVATE
-                           ${CMOCKA_PUBLIC_INCLUDE_DIRS}
-                           ../include
-                           )
-add_test(NAME utils COMMAND ${PROJECT_NAME})
+add_test(NAME utils COMMAND test_utils 1)

--- a/utils/tests/test_comparison.c
+++ b/utils/tests/test_comparison.c
@@ -1,0 +1,36 @@
+#include <math.h>
+
+#include <unity.h>
+
+#include "comparison.h"
+
+void setUp(void) {
+    // set stuff up here
+}
+
+void tearDown(void) {
+    // clean stuff up here
+}
+
+void test_relative_equality(void) {
+    double x = 1.0;
+    double y = cos(0.0);
+    double eps = 1.0e-8;
+    TEST_ASSERT_EQUAL_INT(1, test_relative_equality(x, y, eps))
+}
+
+void test_relative_inequality(void) {
+    double x = 1.0;
+    double y = cos(0.0);
+    double eps = 1.0e-15;
+    TEST_ASSERT_EQUAL_INT(0, test_relative_equality(x, y, eps))
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_relative_equality);
+    RUN_TEST(test_relative_inequality);
+    return UNITY_END();
+}
+
+

--- a/utils/tests/test_comparison.c
+++ b/utils/tests/test_comparison.c
@@ -1,36 +1,126 @@
 #include <math.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <cmocka.h>
+#include "../include/comparison.h"
 
-#include <unity.h>
 
-#include "comparison.h"
-
-void setUp(void) {
-    // set stuff up here
-}
-
-void tearDown(void) {
-    // clean stuff up here
-}
-
-void test_relative_equality(void) {
+void test_relative_equality(void **state)
+{
     double x = 1.0;
-    double y = cos(0.0);
+    double y = 0.999;
+    double eps = 0.01;
+    assert_int_equal(1, is_relatively_equal(x, y, eps));
+}
+
+void test_relative_inequality(void **state)
+{
+    double x = 1.0;
+    double y = 0.9;
+    double eps = 0.01;
+    assert_int_equal(0, is_relatively_equal(x, y, eps));
+}
+
+void test_relative_inequality_a_inf(void **state)
+{
+    double x = INFINITY;
+    double y = 1.0;
+    double eps = 0.01;
+    assert_int_equal(0, is_relatively_equal(x, y, eps));
+}
+
+void test_relative_inequality_b_inf(void **state)
+{
+    double x = 1.0;
+    double y = INFINITY;
+    double eps = 0.01;
+    assert_int_equal(0, is_relatively_equal(x, y, eps));
+}
+
+void test_relative_inequality_a_nan(void **state)
+{
+    double x = NAN;
+    double y = 1.0;
+    double eps = 0.01;
+    assert_int_equal(0, is_relatively_equal(x, y, eps));
+}
+
+void test_relative_inequality_b_nan(void **state)
+{
+    double x = 1.0;
+    double y = NAN;
     double eps = 1.0e-8;
-    TEST_ASSERT_EQUAL_INT(1, test_relative_equality(x, y, eps))
+    assert_int_equal(0, is_relatively_equal(x, y, eps));
 }
 
-void test_relative_inequality(void) {
+void test_almost_equality(void **state)
+{
+    int maxulps = 3;
+    double x = 0.0;
+    double y = x;
+    for (int i = 0; i < maxulps - 1; i++)
+        y = nextafter(y, 1.0);
+    assert_int_equal(1, is_almost_equal(x, y, maxulps));
+}
+
+void test_almost_inequality(void **state)
+{
+    int maxulps = 3;
+    double x = 0.0;
+    double y = x;
+    for (int i = 0; i < maxulps + 1; i++)
+        y = nextafter(y, 1.0);
+    assert_int_equal(0, is_almost_equal(x, y, maxulps));
+}
+
+void test_almost_inequality_a_inf(void **state)
+{
+    int maxulps = 3;
+    double x = INFINITY;
+    double y = 1.0;
+    assert_int_equal(0, is_almost_equal(x, y, maxulps));
+}
+
+void test_almost_inequality_b_inf(void **state)
+{
+    int maxulps = 3;
     double x = 1.0;
-    double y = cos(0.0);
-    double eps = 1.0e-15;
-    TEST_ASSERT_EQUAL_INT(0, test_relative_equality(x, y, eps))
+    double y = INFINITY;
+    assert_int_equal(0, is_almost_equal(x, y, maxulps));
 }
 
-int main(void) {
-    UNITY_BEGIN();
-    RUN_TEST(test_relative_equality);
-    RUN_TEST(test_relative_inequality);
-    return UNITY_END();
+void test_almost_inequality_a_nan(void **state)
+{
+    int maxulps = 3;
+    double x = NAN;
+    double y = 1.0;
+    assert_int_equal(0, is_almost_equal(x, y, maxulps));
 }
 
+void test_almost_inequality_b_nan(void **state)
+{
+    int maxulps = 3;
+    double x = 1.0;
+    double y = NAN;
+    assert_int_equal(0, is_almost_equal(x, y, maxulps));
+}
 
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_relative_equality),
+        cmocka_unit_test(test_relative_inequality),
+        cmocka_unit_test(test_relative_inequality_a_inf),
+        cmocka_unit_test(test_relative_inequality_b_inf),
+        cmocka_unit_test(test_relative_inequality_a_nan),
+        cmocka_unit_test(test_relative_inequality_b_nan),
+        cmocka_unit_test(test_almost_equality),
+        cmocka_unit_test(test_almost_inequality),
+        cmocka_unit_test(test_almost_inequality_a_inf),
+        cmocka_unit_test(test_almost_inequality_b_inf),
+        cmocka_unit_test(test_almost_inequality_a_nan),
+        cmocka_unit_test(test_almost_inequality_b_nan),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Pull request provides two functions allowing one to compare floating-point numbers more reliably and replaces existing direct comparisons (using `!=` operator) with one of these functions `is_almost_equal()`.

Since these functions are pretty generic (all other submodules may potentially need to use them at some point) I decided to create a new submodule called *utils* for such functions. If you think these function should be placed somewhere else, I'm open for suggestions.