### PR TITLE
fix CPU temp, voltage, current reads

### DIFF
--- a/mcp/housekeeping/computer_sensors.c
+++ b/mcp/housekeeping/computer_sensors.c
@@ -36,13 +36,15 @@
 #include <channels_tng.h>
 #include "computer_sensors.h"
 
-#define CH_TEMP_CPU0 1
-#define CH_TEMP_CPU1 2
+// verified by running `sensors` in bash and comparing output to
+// `sensors_get_value`
+#define CH_TEMP_CPU0 4
+#define CH_TEMP_CPU1 8
 
 #define CH_VOLT_12V  0
-#define CH_VOLT_5V   1
-#define CH_VOLT_BATT 2
-#define CH_VOLT_CURRENT 5
+#define CH_VOLT_5V   4
+#define CH_VOLT_BATT 8
+#define CH_VOLT_CURRENT 20
 
 #define CHIP_IMANAGER 0
 #define CHIP_CPU 1


### PR DESCRIPTION
These constants appeared to be out of date, giving bad CPU state readouts when compared with output of  `sensors` on command line.

We stumbled on this while timing `mcp` x Hz loops, and investigating the cause of a ~0.02 s latency incurred every ~2s. We isolated it to this file, and replicated the behavior in a standalone program with `sensors_get_value()` calls. Root cause not yet identified, suspected to be a resource conflict with some other program that is also querying CPU sensors at a .5 Hz cadence.