### PR TITLE
Iandev

### DIFF
--- a/mcp/housekeeping/CMakeLists.txt
+++ b/mcp/housekeeping/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(housekeeping STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_sharing_server.c
     ${CMAKE_CURRENT_SOURCE_DIR}/labjack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/labjack_functions.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/labjack_test.c
     ${CMAKE_CURRENT_SOURCE_DIR}/multiplexed_labjack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/therm_heater.c
     ${CMAKE_CURRENT_SOURCE_DIR}/watchdog.c

--- a/mcp/housekeeping/labjack_test.c
+++ b/mcp/housekeeping/labjack_test.c
@@ -1,0 +1,54 @@
+/***************************************************************************
+ mcp: the TIM master control program
+ 
+ This software is copyright (C) 2002-2006 University of Toronto
+ 
+ This file is part of mcp.
+ 
+ mcp is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ at your option) any later version.
+ 
+ mcp is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with mcp; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ 
+ created by Ian Lowe 1-24-23
+ **************************************************************************/
+
+
+/*************************************************************************
+ 
+ labjack_test.c -- mcp code to provide a test setup for a labjack on ubuntu 20.04
+ 
+ *************************************************************************/
+
+
+#include <math.h>
+#include <stdio.h>
+
+#include "mcp.h"
+#include "channels_tng.h"
+#include "lut.h"
+#include "tx.h"
+#include "command_struct.h"
+#include "labjack.h"
+#include "labjack_functions.h"
+#include "blast.h"
+#include "multiplexed_labjack.h"
+#include "labjack_test.h"
+
+extern labjack_state_t state[NUM_LABJACKS];
+
+void read_from_lj(void) {
+    float read_val = 0;
+    // read the value on analog input 0 to labjack cryo 1 (192.168.1.110)
+    read_val = labjack_get_value(LABJACK_CRYO_1, 0);
+    blast_info("We see %f volts on analog input 0", read_val);
+}

--- a/mcp/include/labjack_test.h
+++ b/mcp/include/labjack_test.h
@@ -1,0 +1,33 @@
+/***************************************************************************
+ mcp: the TIM master control program
+ 
+ This software is copyright (C) 2002-2006 University of Toronto
+ 
+ This file is part of mcp.
+ 
+ mcp is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ at your option) any later version.
+ 
+ mcp is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with mcp; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ 
+ created by Ian Lowe 1-24-23
+ **************************************************************************/
+
+
+/*************************************************************************
+ 
+ labjack_test.c -- mcp code to provide a test setup for a labjack on ubuntu 20.04
+ 
+ *************************************************************************/
+
+
+void read_from_lj(void);

--- a/mcp/mcp.c
+++ b/mcp/mcp.c
@@ -59,6 +59,7 @@
 #include "labjack.h"
 #include "labjack_functions.h"
 #include "multiplexed_labjack.h"
+#include "labjack_test.h"
 
 #include "acs.h"
 #include "actuators.h"
@@ -180,6 +181,9 @@ void * lj_connection_handler(void *arg) {
     }
     // LABJACKS
     blast_info("I am now in charge, initializing LJs");
+    // initialize labjack cryo 1 for testing purposes
+    labjack_networking_init(LABJACK_CRYO_1, LABJACK_CRYO_NCHAN, LABJACK_CRYO_SPP);
+    initialize_labjack_commands(LABJACK_CRYO_1);
     // Set the queue to allow new set
     // leaving the queue in here because it will be used in the future.
     CommandData.Labjack_Queue.set_q = 1;
@@ -282,6 +286,7 @@ static void mcp_2hz_routines(void)
 static void mcp_1hz_routines(void)
 {
     force_incharge();
+    read_from_lj();
     int ready = !superframe_counter[RATE_488HZ];
     // int ready = 1;
     // int i = 0;
@@ -537,7 +542,9 @@ blast_info("Finished initializing Beaglebones..."); */
   initialize_motors();
 
 // LJ THREAD
-  lj_init_thread = ph_thread_spawn(lj_connection_handler, NULL);
+  // lj_init_thread = ph_thread_spawn(lj_connection_handler, NULL);
+  labjack_networking_init(LABJACK_CRYO_1, LABJACK_CRYO_NCHAN, LABJACK_CRYO_SPP);
+  initialize_labjack_commands(LABJACK_CRYO_1);
 
   pthread_create(&CPU_monitor, NULL, CPU_health, NULL);
 


### PR DESCRIPTION
Added back a minimal 'print to log' test labjack function that reads the value off of AIN0 for labjack expected at "labjack1" or 192.168.1.110. This has been tested to work with the older debian8 FCs and displays identically 0 when a labjack is disconnected from the network or whatever the register voltage is when it is connected.