### PR TITLE
issue-33: Make mcp fail gracefully when no pilot target

### DIFF
--- a/mcp/communications/include/pilot.h
+++ b/mcp/communications/include/pilot.h
@@ -36,7 +36,12 @@
 
 extern struct Fifo pilot_fifo;
 
-void pilot_compress_and_send(void *);
+/**
+ * @brief Initialize UDP connection using BITServer.
+ *
+ * @param telemetries List of available telemetries.
+ */
+void pilot_compress_and_send(void *telemetries);
 
 
 #endif /* INCLUDE_PILOT_H */


### PR DESCRIPTION
At the moment, there are no unit tests to cover the changes due to the relatively high complexity of the function where the changes occurred (may need refactoring). So I did some "system" tests instead by running `mcp` and varying the content of the `/etc/hosts`.

With all expected hosts (e.g. `highbay`, `gollum`, 'smeagol`, and `galadriel`) defined in `/etc/hosts`
```
$ cat /etc/hosts
127.0.1.1       ubuntu-focal    ubuntu-focal
192.0.0.3       highbay
192.0.0.5       gollum
192.0.0.7       smeagol
192.0.0.11      galadriel
```
`mcp` runs as expected.
```
>Apr-04-23 16:43:20.862> Schedu: System: Startup
-Apr-04-23 16:43:20.862- Schedu: System: I am not South.

-Apr-04-23 16:43:20.862- Schedu: channels_tng.c:482 (channels_initialize):Allocating 500 bytes for 201 channels at 1HZ
-Apr-04-23 16:43:20.862- Schedu: channels_tng.c:482 (channels_initialize):Allocating 855 bytes for 320 channels at 5HZ
-Apr-04-23 16:43:20.862- Schedu: channels_tng.c:482 (channels_initialize):Allocating 201 bytes for 77 channels at 100HZ
-Apr-04-23 16:43:20.862- Schedu: channels_tng.c:482 (channels_initialize):Allocating 234 bytes for 68 channels at 200HZ
-Apr-04-23 16:43:20.862- Schedu: channels_tng.c:482 (channels_initialize):Allocating 4 bytes for 1 channels at 244HZ
-Apr-04-23 16:43:20.862- Schedu: channels_tng.c:482 (channels_initialize):Allocating 4 bytes for 1 channels at 488HZ
>Apr-04-23 16:43:20.864> Schedu: channels_tng.c:516 (channels_initialize):Successfully initialized Channels data structures
-Apr-04-23 16:43:20.864- Schedu: /home/vagrant/tim/git/TIMflight/mcp/mcp.c:484 (main):Commands: MCP Command List Version: $Revision: 5.2 $
>Apr-04-23 16:43:20.864> Schedu: dsp1760.c:475 (initialize_dsp1760_interface):Initialized gyroscope interface
>Apr-04-23 16:43:20.865>   FIFO: WatchFIFO startup

-Apr-04-23 16:43:20.865-  COMM1: sip.c:92 (sip_setserial):Connecting to sip port /dev/ttyCOMM1...
*Apr-04-23 16:43:20.865*  COMM1: sip.c:95 (sip_setserial):Unable to open serial port
$Apr-04-23 16:43:20.865$   FIFO: Unable to open FIFO: No such file or directory
$$ Last error is THREAD FATAL. Thread [  FIFO (49653)] exits.
-Apr-04-23 16:43:20.865-  COMM2: sip.c:92 (sip_setserial):Connecting to sip port /dev/ttyCOMM2...
*Apr-04-23 16:43:20.865*  COMM2: sip.c:95 (sip_setserial):Unable to open serial port
Total of 1 linklists loaded from "/data/etc/linklists/"
*Apr-04-23 16:43:20.866* Highra: comms_serial.c:208 (comms_serial_connect):Could not open terminal '/dev/ttyHighRate':No such file or directory
-Apr-04-23 16:43:20.866- Schedu: /home/vagrant/tim/git/TIMflight/mcp/scheduler_tng.c:366 (InitSched):Scheduler: schedule file initialisation begins.
-Apr-04-23 16:43:20.866-  49659: diskmanager_tng.c:1632 (initialize_diskmanager):Beginning initialize_dismanager.
#Apr-04-23 16:43:20.866# Schedu: /home/vagrant/tim/git/TIMflight/mcp/scheduler_tng.c:101 (LoadSchedFile):********************************************
*** Schedule: /data/etc/blast/happy.north.sch

*Apr-04-23 16:43:20.866* Biphas: mpsse.c:149 (open_matching_device):no device found
*Apr-04-23 16:43:20.866* Biphas: mpsse.c:293 (mpsse_open):unable to open ftdi device with vid 0403, pid 6011, description '*' and serial '*'
*Apr-04-23 16:43:20.866* Schedu: Scheduler: Unable to open schedule file /data/etc/blast/happy.north.sch: No such file or directory
#Apr-04-23 16:43:20.866# Schedu: /home/vagrant/tim/git/TIMflight/mcp/scheduler_tng.c:101 (LoadSchedFile):********************************************
*** Schedule: /data/etc/blast/happy.mid.sch

*Apr-04-23 16:43:20.866* Schedu: Scheduler: Unable to open schedule file /data/etc/blast/happy.mid.sch: No such file or directory
#Apr-04-23 16:43:20.866# Schedu: /home/vagrant/tim/git/TIMflight/mcp/scheduler_tng.c:101 (LoadSchedFile):********************************************
*** Schedule: /data/etc/blast/happy.south.sch

*Apr-04-23 16:43:20.866* Schedu: Scheduler: Unable to open schedule file /data/etc/blast/happy.south.sch: No such file or directory
#Apr-04-23 16:43:20.866# Schedu: /home/vagrant/tim/git/TIMflight/mcp/scheduler_tng.c:101 (LoadSchedFile):********************************************
*** Schedule: /data/etc/blast/sad.north.sch

*Apr-04-23 16:43:20.866* Schedu: Scheduler: Unable to open schedule file /data/etc/blast/sad.north.sch: No such file or directory
-Apr-04-23 16:43:20.866-  49656: bitserver.c:286 (initBITSender):Initializing BITSender:
#Apr-04-23 16:43:20.866# Schedu: /home/vagrant/tim/git/TIMflight/mcp/scheduler_tng.c:101 (LoadSchedFile):********************************************
*** Schedule: /data/etc/blast/sad.mid.sch

=Apr-04-23 16:43:20.866= Biphas: bi0.c:409 (biphase_writer):Error opening mpsse. Will retry every 5s
*Apr-04-23 16:43:20.866* Schedu: Scheduler: Unable to open schedule file /data/etc/blast/sad.mid.sch: No such file or directory
-Apr-04-23 16:43:20.866- Biphas: bi0.c:413 (biphase_writer):Defaulting to not in charge
#Apr-04-23 16:43:20.866# Schedu: /home/vagrant/tim/git/TIMflight/mcp/scheduler_tng.c:101 (LoadSchedFile):********************************************
*** Schedule: /data/etc/blast/sad.south.sch

*Apr-04-23 16:43:20.866* Schedu: Scheduler: Unable to open schedule file /data/etc/blast/sad.south.sch: No such file or directory
-Apr-04-23 16:43:20.866-  49656: bitserver.c:368 (initBITSender):-> SendTo highbay:31213
-Apr-04-23 16:43:20.866-  49656: bitserver.c:286 (initBITSender):Initializing BITSender:
-Apr-04-23 16:43:20.866-  49656: bitserver.c:368 (initBITSender):-> SendTo gollum:31213
-Apr-04-23 16:43:20.867-  49656: bitserver.c:286 (initBITSender):Initializing BITSender:
-Apr-04-23 16:43:20.867-  49656: bitserver.c:368 (initBITSender):-> SendTo smeagol:31213
-Apr-04-23 16:43:20.867-  49656: bitserver.c:286 (initBITSender):Initializing BITSender:
-Apr-04-23 16:43:20.867-  49656: bitserver.c:368 (initBITSender):-> SendTo galadriel:31213
-Apr-04-23 16:43:20.867-  Pilot: pilot.c:91 (pilot_compress_and_send):serial is dfe2
-Apr-04-23 16:43:20.867-  Pilot: pilot.c:94 (pilot_compress_and_send):Pilot linklist set to "all_telemetry.ll"
-Apr-04-23 16:43:20.867- Schedu: labjack.c:600 (connect_lj):Connecting to labjack1
-Apr-04-23 16:43:20.869- Schedu: labjack.c:600 (connect_lj):Connecting to labjack2
-Apr-04-23 16:43:20.870- Schedu: xsc_network.c:243 (connect_xsc):Connecting to 192.168.1.7
-Apr-04-23 16:43:20.870- Schedu: xsc_network.c:243 (connect_xsc):Connecting to 192.168.1.8
*Apr-04-23 16:43:20.870* Schedu: xsc_pointing.c:114 (xsc_trigger):Could not open /sys/class/gpio/gpio504/value for writing:No such file or directory
*Apr-04-23 16:43:20.870* Schedu: xsc_pointing.c:114 (xsc_trigger):Could not open /sys/class/gpio/gpio505/value for writing:No such file or directory
*Apr-04-23 16:43:20.870* Schedu: magnetometer.c:330 (initialize_magnetometer):Could not open Magnetometer port /dev/ttyMAG
*Apr-04-23 16:43:20.870*  49668: computer_sensors.c:122 (initialize_CPU_sensors):Could not get sensors chips!
-Apr-04-23 16:43:20.870-    GPS: gps.c:48 (GPSMonitor):Started GPS thread
>Apr-04-23 16:43:2-Apr-04-23 16:43:20.871-   DGPS: csbf_dgps.c:63 (csbf_setserial):Connecting to sip port /dev/ttyCSBFGPS...
*Apr-04-23 16:43:20.871*   DGPS: csbf_dgps.c:66 (csbf_setserial):Unable to open serial port
>Apr-04-23 16:43:20.872> ActBus: ActuatorBus startup.
-Apr-04-23 16:43:20.872- ActBus: actuators.c:1492 (ActuatorBus):Not in charge.  Waiting.
-Apr-04-23 16:43:20.872- Schedu: chrgctrl.c:158 (startChrgCtrl):startChrgCtrl: creating charge controller 0 ModBus thread
-Apr-04-23 16:43:20.872- Schedu: chrgctrl.c:158 (startChrgCtrl):startChrgCtrl: creating charge controller 1 ModBus thread
*Apr-04-23 16:43:20.872* Schedu: data_sharing_server.c:71 (data_sharing_init):Cannot find shared.ll for data sharing
-Apr-04-23 16:43:20.872- ChrgC1: chrgctrl.c:177 (chrgctrlComm):starting controller #1 at IP 192.168.1.253
-Apr-04-23 16:43:20.872- ChrgC2: chrgctrl.c:177 (chrgctrlComm):starting controller #2 at IP 192.168.1.252
-Apr-04-23 16:43:20.873-   Main: labjack.c:667 (labjack_choose_execute):no queue selected, trying again every 1s
-Apr-04-23 16:43:20.873-   Main: store_data.c:335 (store_data_hk):store_disks_ready is not ready.
*Apr-04-23 16:43:20.876*   Main: channels_tng.c:397 (channels_find_by_name):Could not find clin_if_y!

-Apr-04-23 16:43:20.876-   Main: balance.c:73 (ControlBalance):Init ControlBalance
-Apr-04-23 16:43:20.967- Motors: ec_motors.c:1626 (motor_control):Not in charge.  Waiting for control.
>Apr-04-23 16:43:20.967> Motors: ec_motors.c:1630 (motor_control):Starting Motor Control
-Apr-04-23 16:43:20.967-  Pilot: pilot.c:91 (pilot_compress_and_send):serial is dfe2
                                         Last message repeats 1 times
-Apr-04-23 16:43:20.977- Motors: ec_motors.c:1638 (motor_control):Initialized eth1
-Apr-04-23 16:43:20.977- Motors: ec_motors.c:1640 (motor_control):Attempting configure to EtherCat devices.
*Apr-04-23 16:43:20.991* LJCMD0: labjack.c:717 (labjack_cmd_thread):Could not resolve labjack1!
beginning ecx_config_map_group
*Apr-04-23 16:43:21.028* Motors: No motor controller slaves found on the network!: Resource temporarily unavailable
beginning ecx_config_map_group
=Apr-04-23 16:43:21.028= Motors: ec_motors.c:1513 (configure_ec_motors):Warning ec_config_map(&io_map) return null map size.
-Apr-04-23 16:43:21.028- Motors: ec_motors.c:1150 (map_motor_vars):Starting map_motor_vars.
-Apr-04-23 16:43:21.036- Motors: ec_motors.c:1546 (configure_ec_motors):Setting the EtherCAT devices in operational mode.
*Apr-04-23 16:43:21.062* LJCMD1: labjack.c:717 (labjack_cmd_thread):Could not resolve labjack2!
*Apr-04-23 16:43:21.066*   Main: lut.c:75 (LutInit):LUT: error reading LUT file /data/etc/blast/clino_tng.lut: no calibration

-Apr-04-23 16:43:21.067-   Main: /home/vagrant/tim/git/TIMflight/mcp/scheduler_tng.c:397 (DoSched):Calling DoSched for the First Time
-Apr-04-23 16:43:21.069-  Pilot: pilot.c:91 (pilot_compress_and_send):serial is dfe2
                                         Last message repeats 2 times
-Apr-04-23 16:43:21.357-  49659: diskmanager_tng.c:515 (diskpool_mount_disk):Mounting /dev/disk/by-uuid/bf17960b-f52c-42c4-8002-86510ed95488 at /data/mcp_hd0 with filesystem type xfs
-Apr-04-23 16:43:21.357-  49659: diskmanager_tng.c:520 (diskpool_mount_disk):Could not mount /dev/disk/by-uuid/bf17960b-f52c-42c4-8002-86510ed95488 at /data/mcp_hd0 with filesystem type xfs: No such file or directory
*Apr-04-23 16:43:21.363* Schedu: dsp1760.c:403 (dsp1760_connect_gyro):


Could not open Gyro port /dev/ttyGYRO0


-Apr-04-23 16:43:21.370-  Pilot: pilot.c:91 (pilot_compress_and_send):serial is dfe2
                                         Last message repeats 5 times
-Apr-04-23 16:43:21.873- ActBus: actuators.c:1508 (ActuatorBus):In Charge! Attempting to initalize.
*Apr-04-23 16:43:21.873* ActBus: Unable to open serial port (/dev/ttyACT): No such file or directory
-Apr-04-23 16:43:21.972-  Pilot: pilot.c:91 (pilot_compress_and_send):serial is dfe2
                                         Last message repeats 10 times
-Apr-04-23 16:43:22.866- Highra: highrate.c:131 (highrate_compress_and_send):Could not connect to highrate port. Will try again in 2 seconds...
*Apr-04-23 16:43:22.866* Highra: comms_serial.c:208 (comms_serial_connect):Could not open terminal '/dev/ttyHighRate':No such file or directory
-Apr-04-23 16:43:22.878-  Pilot: pilot.c:91 (pilot_compress_and_send):serial is dfe20.871>   DGPS: csbf_dgps.c:312 (DGPSMonitor):Starting DGPSMonitor thread.
....
```

When *any* of these hosts is commented out, for example:

```
127.0.1.1       ubuntu-focal    ubuntu-focal
#192.0.0.3       highbay
192.0.0.5       gollum
192.0.0.7       smeagol
192.0.0.11     galadriel
```
 `mcp` exits gracefully without a segfault
 ```
 [non-relevant log messages removed for clarity]
 *Apr-04-23 15:58:49.375*  47323: bitserver.c:342 (initBITSender):host lookup highbay failed.
!Apr-04-23 15:58:49.375!  47323: Cannot resolve host 'highbay' (hint: check entries in /etc/hosts): Resource temporarily unavailable
!! Last error is FATAL.  Cannot continue.
 ```