### PR TITLE
EVTM sender for MCP

### DIFF
--- a/common/bitserver.c
+++ b/common/bitserver.c
@@ -123,7 +123,7 @@ void * sendDataThread(void *arg) {
   uint8_t *buffer;
   uint8_t flags;
 
-  blast_info("sendDataThread added for Server Address: %s", inet_ntoa(server->send_addr.sin_addr));
+  // blast_info("sendDataThread added for Server Address: %s", inet_ntoa(server->send_addr.sin_addr));
 
   header = (uint8_t *) calloc(PACKET_HEADER_SIZE+server->packet_maxsize, 1);
 
@@ -143,7 +143,7 @@ void * sendDataThread(void *arg) {
           blast_err("cannot send headerless multi-packet message.");
         } else {
           // printf("Sending headerless packet\n");
-          blast_info("sendto headerless %d bytes, %s", size, inet_ntoa(server->send_addr.sin_addr));
+          // blast_info("sendto headerless %d bytes, %s", size, inet_ntoa(server->send_addr.sin_addr));
           if (sendto(server->sck, buffer, size,
             MSG_NOSIGNAL, (struct sockaddr *) &(server->send_addr),
             server->slen) < 0) {
@@ -166,20 +166,20 @@ void * sendDataThread(void *arg) {
             MSG_NOSIGNAL | MSG_MORE,
             (struct sockaddr *) &(server->send_addr),
             server->slen) < 0) {
-              blast_err("sendTo failed (errno %d): %s", errno, inet_ntoa(server->send_addr.sin_addr));
-          } else {
-            blast_info("sendto header %d bytes, %s", PACKET_HEADER_SIZE, inet_ntoa(server->send_addr.sin_addr));
-          }
+              // blast_err("sendTo failed (errno %d): %s", errno, inet_ntoa(server->send_addr.sin_addr));
+          } // else {
+            // blast_info("sendto header %d bytes, %s", PACKET_HEADER_SIZE, inet_ntoa(server->send_addr.sin_addr));
+          // }
 
           // add data to packet and send
           // if (sendto(server->sck, buffer+(i*packet_maxsize), packet_size,
           if (sendto(server->sck, pkt_buffer, packet_size,
             MSG_NOSIGNAL, (struct sockaddr *) &(server->send_addr),
             server->slen) < 0) {
-              blast_err("sendTo failed (errno %d): %s", errno, inet_ntoa(server->send_addr.sin_addr));
-          } else {
-            blast_info("sendto data %d bytes, %s", packet_size, inet_ntoa(server->send_addr.sin_addr));
-          }
+              // blast_err("sendTo failed (errno %d): %s", errno, inet_ntoa(server->send_addr.sin_addr));
+          } // else {
+            // blast_info("sendto data %d bytes, %s", packet_size, inet_ntoa(server->send_addr.sin_addr));
+          // }
 
 #else // for QNX kernel
         // TODO(shubh): QNX kernel has not been tested with multicast EVTM packets

--- a/liblinklist/linklist.c
+++ b/liblinklist/linklist.c
@@ -334,7 +334,7 @@ int load_all_linklists_opt(superframe_t * superframe, char * linklistdir, linkli
   int num = 0;
 
   if (n<0) { 
-    linklist_fatal("Cannot open the linklists directory %s", linklistdir);
+    linklist_fatal("Cannot open the linklists directory %s\n", linklistdir);
   } else if (n>=MAX_NUM_LINKLIST_FILES) { 
     linklist_fatal("Max linklists in %s\n",linklistdir);
   }
@@ -358,13 +358,16 @@ int load_all_linklists_opt(superframe_t * superframe, char * linklistdir, linkli
         snprintf(full_path_name, LINKLIST_MAX_FILENAME_SIZE, "%s%s",linklistdir, dir[i]->d_name);
         
         if ((ll_array[num] = parse_linklist_format_opt(superframe, full_path_name, flags)) == NULL) {
-          linklist_fatal("Unable to load linklist at %s", full_path_name);
+          linklist_fatal("Unable to load linklist at %s\n", full_path_name);
         }
         num++;
         break;
       }
     }
   }
+
+  // TODO(shubh): if there were not enough links in the directory above, the superframe might be arbitrarily alloted
+  // to any telemetry downlink: Not Good
   ll_array[num] = generate_superframe_linklist_opt(superframe, flags); // last linklist contains all the telemetry items
   ll_array[num+1] = NULL; // null terminate the list
 

--- a/mcp/communications/CMakeLists.txt
+++ b/mcp/communications/CMakeLists.txt
@@ -25,3 +25,7 @@ target_link_libraries(communications PRIVATE
 if (ENABLE_STYLE_CHECK)
     check_style(communications)
 endif()
+
+if (ENABLE_TESTING)
+    add_subdirectory(tests)
+endif(ENABLE_TESTING)

--- a/mcp/communications/CMakeLists.txt
+++ b/mcp/communications/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library (communications STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/biphase_hardware.c
     ${CMAKE_CURRENT_SOURCE_DIR}/pilot.c
     ${CMAKE_CURRENT_SOURCE_DIR}/highrate.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/evtm.c
 )
 define_file_basename_for_sources(communications)
 

--- a/mcp/communications/evtm.c
+++ b/mcp/communications/evtm.c
@@ -67,7 +67,7 @@ struct Fifo evtm_fifo_tdrss = {0};
  * 
  * @return 0 if successful, -1 if not.
  */
-int setup_EVTM_config(struct evtmInfo *evtm_info, struct evtmSetup *evtm_setup) {
+int EVTM_setup_config(struct evtmInfo *evtm_info, struct evtmSetup *evtm_setup) {
     evtm_setup->telemetries = evtm_info->telemetries;
     evtm_setup->evtm_type = evtm_info->evtm_type;
 
@@ -123,8 +123,8 @@ int setup_EVTM_config(struct evtmInfo *evtm_info, struct evtmSetup *evtm_setup) 
  * 
  * @return 1 if not testing, 0 if testing.
  */
-int enable_EVTM_loop() {
-    return 0; // default behavior is to not test and run the infinite loop
+int EVTM_enable_loop() {
+    return 1; // default behavior is to not test and run the infinite loop
     // we make a mock function when testing around this function
 }
 
@@ -217,12 +217,12 @@ void *EVTM_loop_body(struct evtmSetup *es) {
  *
  * @param evtm_info Struct containing telemetries and evtm type.
  */
-void evtm_compress_and_send(struct evtmInfo *evtm_info) {
+void EVTM_compress_and_send(struct evtmInfo *evtm_info) {
     struct evtmSetup evtm_setup = {{0}};
-    if (setup_EVTM_config(evtm_info, &evtm_setup) != 0) {
+    if (EVTM_setup_config(evtm_info, &evtm_setup) != 0) {
         blast_fatal("EVTM setup failed");
     }
-    while (!enable_EVTM_loop()) {
+    while (EVTM_enable_loop()) {
         EVTM_loop_body(&evtm_setup);
     }
 }

--- a/mcp/communications/evtm.c
+++ b/mcp/communications/evtm.c
@@ -137,7 +137,7 @@ void *EVTM_loop_body(struct evtmSetup *es) {
     es->ll = es->ll_array[es->TELEMETRY_INDEX];
     if (es->ll != es->ll_old) {
         if (es->ll) {
-            blast_info("EVTM %d, %s: serial is 0x%x", es->evtm_type, es->ADDR, \
+            blast_info("EVTM %d, %s: serial is 0x%x (ensure serial hashtables match b/w FC and GS)", es->evtm_type, es->ADDR, \
                     *(uint32_t *) es->ll->serial);
             blast_info("EVTM %d, %s: linklist set to \"%s\"", es->evtm_type, \
                     es->ADDR, es->ll->name);

--- a/mcp/communications/evtm.c
+++ b/mcp/communications/evtm.c
@@ -137,8 +137,8 @@ void *EVTM_loop_body(struct evtmSetup *es) {
     es->ll = es->ll_array[es->TELEMETRY_INDEX];
     if (es->ll != es->ll_old) {
         if (es->ll) {
-            blast_info("EVTM %d, %s: serial is 0x%x (ensure serial hashtables match b/w FC and GS)", es->evtm_type, es->ADDR, \
-                    *(uint32_t *) es->ll->serial);
+            blast_info("EVTM %d, %s: serial is 0x%x (ensure serial hashtables match b/w FC and GS)", \
+                es->evtm_type, es->ADDR, *(uint32_t *) es->ll->serial);
             blast_info("EVTM %d, %s: linklist set to \"%s\"", es->evtm_type, \
                     es->ADDR, es->ll->name);
         } else {

--- a/mcp/communications/evtm.c
+++ b/mcp/communications/evtm.c
@@ -1,0 +1,190 @@
+/* 
+ * evtm.c: Ethernet Via TeleMetry (EVTM)
+ * Used for sending UDP multicast packets via LOS and TDRSS links
+ * 
+ * This software  is copyright 
+ *  (C) University of Pennsylvania, Philadelphia 2023
+ *
+ * This file is part of mcp, as used for the Terahertz Intensity Mapper (TIM).
+ *
+ * mcp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mcp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with mcp; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * History:
+ * Created on: Sep 19, 2018 by Shubh Agrawal
+ */
+
+#include <math.h>
+#include <arpa/inet.h> // socket stuff
+#include <netinet/in.h> // socket stuff
+#include <stdio.h> // socket stuff
+#include <sys/types.h> // socket types
+#include <sys/socket.h> // socket stuff
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h> // threads
+#include <openssl/md5.h>
+#include <float.h>
+
+// Javier's special libraries
+#include <linklist.h>
+#include <linklist_compress.h>
+
+#include "mcp.h"
+#include "FIFO.h"
+#include "bitserver.h"
+#include "evtm.h"
+#include "blast.h"
+#include "mputs.h"
+#include "command_struct.h"
+
+extern int16_t InCharge;
+
+struct Fifo evtm_fifo_los = {0};
+struct Fifo evtm_fifo_tdrss = {0};
+
+/**
+ * @brief Takes a pointer to a list of telemetries, and a type of evtm (LOS or TDRSS)
+ * and compresses the data into a packet and sends it over UDP multicast.
+ *
+ * @param telemetries List of available telemetries.
+ * @param evtm_type Type of evtm (LOS or TDRSS)
+ */
+void evtm_compress_and_send(struct evtmInfo *evtm_info) {
+    void *telemetries = evtm_info->telemetries;
+    enum evtmType evtm_type = evtm_info->evtm_type;
+
+    int PORT;
+    char *ADDR;
+    int TELEMETRY_INDEX;
+    struct Fifo *evtm_fifo;
+    double BANDWIDTH;
+    double ALLFRAME_FRACTION;
+
+    if (evtm_type == EVTM_LOS) {
+        // send to LOS multicast address
+        PORT = EVTM_PORT_LOS;
+        ADDR = EVTM_ADDR_LOS;
+        TELEMETRY_INDEX = EVTM_LOS_TELEMETRY_INDEX;
+        evtm_fifo = &evtm_fifo_los;
+    } else if (evtm_type == EVTM_TDRSS) {
+        // send to TDRSS multicast address
+        PORT = EVTM_PORT_TDRSS;
+        ADDR = EVTM_ADDR_TDRSS;
+        TELEMETRY_INDEX = EVTM_TDRSS_TELEMETRY_INDEX;
+        evtm_fifo = &evtm_fifo_tdrss;
+    } else {
+        blast_fatal("Invalid evtm type %d", evtm_type);
+    }
+
+    blast_info("Setting up EVTM %d, %s", evtm_type, ADDR);
+
+    struct BITSender evtm_sender = {0};
+    unsigned int fifosize = MAX(EVTM_MAX_SIZE, superframe->allframe_size);
+    int rc = initBITSender(&evtm_sender, ADDR, PORT, FIFO_LEN, fifosize, EVTM_MAX_PACKET_SIZE);
+    if (rc != 1) { // failing gracefully
+        blast_fatal("initializing BITSender did not work for EVTM %s: check above error msg", ADDR);
+    }
+
+    linklist_t * ll = NULL, * ll_old = NULL, * ll_saved = NULL;
+    linklist_t ** ll_array = telemetries;
+
+    uint8_t * compbuffer = calloc(1, fifosize);
+    unsigned int allframe_bytes = 0;
+    double bandwidth = 0;
+    uint32_t transmit_size = 0;
+
+    char *thread_name;
+    asprintf(&thread_name, "EVTM %d: %s", evtm_type, ADDR);
+    nameThread(thread_name);
+
+    while (1) {
+        ll = ll_array[TELEMETRY_INDEX];
+        if (ll != ll_old) {
+            if (ll) {
+                blast_info("EVTM %d, %s: serial is 0x%x", evtm_type, ADDR, *(uint32_t *) ll->serial);
+                blast_info("EVTM %d, %s: linklist set to \"%s\"", evtm_type, ADDR, ll->name);
+            } else {
+                blast_info("EVTM %d, %s: linklist set to NULL", evtm_type, ADDR);
+            }
+        }
+        ll_old = ll;
+
+        // get the current bandwidth
+        if (evtm_type == EVTM_LOS) {
+            BANDWIDTH = CommandData.biphase_bw;
+            ALLFRAME_FRACTION = CommandData.biphase_allframe_fraction;
+        } else if (evtm_type == EVTM_TDRSS) {
+            BANDWIDTH = CommandData.highrate_bw;
+            ALLFRAME_FRACTION = CommandData.highrate_allframe_fraction;
+        }
+        if ((bandwidth != BANDWIDTH) || (ALLFRAME_FRACTION < 0.0001)) {
+                allframe_bytes = 0;
+        }
+        bandwidth = BANDWIDTH;
+
+        if (!fifoIsEmpty(evtm_fifo) && ll && InCharge) { // data ready to send
+            if (!strcmp(ll->name, FILE_LINKLIST)) {
+                if (ll->blocks[0].i >= ll->blocks[0].n) {
+                    ll_array[TELEMETRY_INDEX] = ll_saved;
+                    continue;
+                }
+
+                // use the full bandwidth
+                transmit_size = bandwidth;
+
+                // fill the downlink buffer as much as the downlink will allow
+                unsigned int bytes_packed = 0;
+                while ((bytes_packed + ll->blk_size) <= transmit_size) {
+                    compress_linklist(compbuffer + bytes_packed, ll, getFifoRead(evtm_fifo));
+                    bytes_packed += ll->blk_size;
+                }
+                decrementFifo(evtm_fifo);
+            } else { // normal linklist
+                ll_saved = ll;
+
+                // send allframe if necessary
+                if (allframe_bytes >= superframe->allframe_size) {
+                    transmit_size = write_allframe(compbuffer, superframe, getFifoRead(evtm_fifo));
+                    allframe_bytes = 0;
+                } else {
+                    transmit_size = MIN(ll->blk_size, bandwidth * (1.0 - ALLFRAME_FRACTION));
+                    // compress the linklist
+                    compress_linklist(compbuffer, ll, getFifoRead(evtm_fifo));
+
+                    // bandwidth limit; frames are 1 Hz, so bandwidth == size
+                    allframe_bytes += bandwidth * ALLFRAME_FRACTION;
+                    decrementFifo(evtm_fifo);
+                }
+            }
+
+            // no packetization if there is nothing to transmit
+            if (!transmit_size) {
+                continue;
+            }
+            // send the data via bitsender
+            setBITSenderSerial(&evtm_sender, *(uint32_t *) ll->serial);
+            setBITSenderFramenum(&evtm_sender, transmit_size);
+            sendToBITSender(&evtm_sender, compbuffer, transmit_size, 0);
+            memset(compbuffer, 0, EVTM_MAX_SIZE);
+        } else {
+            usleep(100000);
+        }
+    }
+}

--- a/mcp/communications/evtm.c
+++ b/mcp/communications/evtm.c
@@ -85,6 +85,7 @@ int setup_EVTM_config(struct evtmInfo *evtm_info, struct evtmSetup *evtm_setup) 
         evtm_setup->evtm_fifo = &evtm_fifo_tdrss;
     } else {
         blast_fatal("Invalid evtm type %d", evtm_setup->evtm_type);
+        return -1; // while we never reach this due to blast_fatal, this is here for unit testing
     }
 
     blast_info("Setting up EVTM %d, %s", evtm_setup->evtm_type, evtm_setup->ADDR);
@@ -95,6 +96,7 @@ int setup_EVTM_config(struct evtmInfo *evtm_info, struct evtmSetup *evtm_setup) 
                 FIFO_LEN, evtm_setup->fifosize, EVTM_MAX_PACKET_SIZE);
     if (rc != 1) { // failing gracefully
         blast_fatal("initializing BITSender did not work for EVTM %s: check above error msg", evtm_setup->ADDR);
+        return -1; // while we never reach this due to blast_fatal, this is here for unit testing
     }
 
     evtm_setup->ll = NULL;

--- a/mcp/communications/include/evtm.h
+++ b/mcp/communications/include/evtm.h
@@ -68,7 +68,7 @@ struct evtmSetup {
     char *ADDR;
     int TELEMETRY_INDEX;
     struct Fifo *evtm_fifo;
-    double BANDWIDTH;
+    double Commanded_Bandwidth;
     double ALLFRAME_FRACTION;
     struct BITSender evtm_sender;
     unsigned int fifosize;
@@ -84,7 +84,7 @@ struct evtmSetup {
 
 int testing_evtm();
 int setup_EVTM_config(struct evtmInfo *evtm_info, struct evtmSetup *evtm_setup);
-void *infinite_loop_EVTM(struct evtmSetup *es);
+void *EVTM_loop_body(struct evtmSetup *es);
 void evtm_compress_and_send(struct evtmInfo *evtm_info);
 
 #endif /* INCLUDE_EVTM_H */

--- a/mcp/communications/include/evtm.h
+++ b/mcp/communications/include/evtm.h
@@ -1,0 +1,64 @@
+/* 
+ * evtm.h: Ethernet Via TeleMetry (EVTM) header file 
+ * 
+ * This software  is copyright 
+ *  (C) University of Pennsylvania, Philadelphia 2023
+ *
+ * This file is part of mcp, as used for the Terahertz Intensity Mapper (TIM).
+ *
+ * mcp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mcp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with mcp; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * History:
+ * Created on: Sep 19, 2018 by Shubh Agrawal
+ */
+
+#ifndef INCLUDE_EVTM_H
+#define INCLUDE_EVTM_H
+
+#define EVTM_PORT_LOS 20001 // port that mcp will spew LOS evtm UDP data to
+#define EVTM_ADDR_LOS "239.255.0.1" // IP that evtm LOS data is sent to
+
+#define EVTM_PORT_TDRSS 20002 // port that mcp will spew evtm TRDSS UDP data to
+#define EVTM_ADDR_TDRSS "239.255.0.2" // IP that evtm TRDSS data is sent to
+// ground station (and groundhog) should be set up to listen to these IPs and ports
+
+#define EVTM_MAX_PACKET_SIZE 1472 // maximum size of a packet to be sent over EVTM
+// MTU (1500) - IPv4 header (20) - UDP header (8)
+#define EVTM_MAX_SIZE (superframe->size*2) // maximum compressed frame size to be send over EVTM
+
+#define FIFO_LEN 10 // length of FIFO buffer
+
+extern struct Fifo evtm_fifo_los;
+extern struct Fifo evtm_fifo_tdrss;
+
+enum evtmType {
+    EVTM_LOS = 0,
+    EVTM_TDRSS = 1,
+    EVTM_NUM_TYPES = 2,
+};
+
+struct evtmInfo {
+    void *telemetries;
+    enum evtmType evtm_type;
+};
+
+/**
+ * @brief Initialize UDP connection using BITServer.
+ *
+ * @param telemetries List of available telemetries.
+ */
+void evtm_compress_and_send(struct evtmInfo *evtm_info);
+
+#endif /* INCLUDE_EVTM_H */

--- a/mcp/communications/include/evtm.h
+++ b/mcp/communications/include/evtm.h
@@ -24,6 +24,10 @@
  * Created on: Sep 19, 2018 by Shubh Agrawal
  */
 
+#include "bitserver.h"
+#include "FIFO.h"
+#include "linklist.h"
+
 #ifndef INCLUDE_EVTM_H
 #define INCLUDE_EVTM_H
 
@@ -40,6 +44,8 @@
 
 #define FIFO_LEN 10 // length of FIFO buffer
 
+#define EVTM_NOT_TESTING 1 // set to 0 if testing
+
 extern struct Fifo evtm_fifo_los;
 extern struct Fifo evtm_fifo_tdrss;
 
@@ -54,11 +60,30 @@ struct evtmInfo {
     enum evtmType evtm_type;
 };
 
-/**
- * @brief Initialize UDP connection using BITServer.
- *
- * @param telemetries List of available telemetries.
- */
+struct evtmSetup {
+    void* telemetries;
+    enum evtmType evtm_type;
+    int PORT;
+    char *ADDR;
+    int TELEMETRY_INDEX;
+    struct Fifo *evtm_fifo;
+    double BANDWIDTH;
+    double ALLFRAME_FRACTION;
+    struct BITSender evtm_sender;
+    unsigned int fifosize;
+    linklist_t * ll; 
+    linklist_t * ll_old;
+    linklist_t * ll_saved;
+    linklist_t ** ll_array;
+    uint8_t * compbuffer;
+    unsigned int allframe_bytes;
+    double bandwidth;
+    uint32_t transmit_size;
+};
+
+int testing_evtm();
+int setup_EVTM_config(struct evtmInfo *evtm_info, struct evtmSetup *evtm_setup);
+void *infinite_loop_EVTM(struct evtmSetup *es);
 void evtm_compress_and_send(struct evtmInfo *evtm_info);
 
 #endif /* INCLUDE_EVTM_H */

--- a/mcp/communications/include/evtm.h
+++ b/mcp/communications/include/evtm.h
@@ -38,8 +38,9 @@
 #define EVTM_ADDR_TDRSS "239.255.0.2" // IP that evtm TRDSS data is sent to
 // ground station (and groundhog) should be set up to listen to these IPs and ports
 
-#define EVTM_MAX_PACKET_SIZE 1472 // maximum size of a packet to be sent over EVTM
-// MTU (1500) - IPv4 header (20) - UDP header (8)
+#define EVTM_MAX_PACKET_SIZE 1460 // maximum size of a packet to be sent over EVTM
+// MTU (1500) - IPv4 header (20) - UDP header (8) - 12 (some other header stuff?)
+// tcpdump gives bad udp length errors
 #define EVTM_MAX_SIZE (superframe->size*2) // maximum compressed frame size to be send over EVTM
 
 #define FIFO_LEN 10 // length of FIFO buffer

--- a/mcp/communications/include/evtm.h
+++ b/mcp/communications/include/evtm.h
@@ -82,9 +82,9 @@ struct evtmSetup {
     uint32_t transmit_size;
 };
 
-int testing_evtm();
-int setup_EVTM_config(struct evtmInfo *evtm_info, struct evtmSetup *evtm_setup);
+int EVTM_enable_loop();
+int EVTM_setup_config(struct evtmInfo *evtm_info, struct evtmSetup *evtm_setup);
 void *EVTM_loop_body(struct evtmSetup *es);
-void evtm_compress_and_send(struct evtmInfo *evtm_info);
+void EVTM_compress_and_send(struct evtmInfo *evtm_info);
 
 #endif /* INCLUDE_EVTM_H */

--- a/mcp/communications/pilot.c
+++ b/mcp/communications/pilot.c
@@ -99,7 +99,7 @@ void pilot_compress_and_send(void *telemetries) {
         ll = ll_array[PILOT_TELEMETRY_INDEX];
         if (ll != ll_old) {
             if (ll) {
-                blast_info("serial is 0x%x", *(uint32_t *) ll->serial);
+                blast_info("serial is 0x%x (ensure serial hashtables match b/w FC and GS)", *(uint32_t *) ll->serial);
                 blast_info("Pilot linklist set to \"%s\"", ll->name);
             } else {
                 blast_info("Pilot linklist set to NULL");

--- a/mcp/communications/tests/CMakeLists.txt
+++ b/mcp/communications/tests/CMakeLists.txt
@@ -1,0 +1,52 @@
+find_package(cmocka CONFIG)
+
+# EVTM code
+
+add_executable(test_evtm
+    ${CMAKE_CURRENT_LIST_DIR}/test_evtm.c
+)
+
+add_dependencies(test_evtm libcmocka)
+
+target_include_directories(test_evtm PRIVATE
+    ${CMOCKA_INCLUDE_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${PROJECT_SOURCE_DIR}/testing # get mock mcp defines
+)
+target_link_libraries(test_evtm PRIVATE
+    ${CMOCKA_LIBRARY}
+    communications
+)
+
+string(CONCAT LINK_FLAGS_WRAP
+    "-Wl,"
+    "--wrap=initBITSender,"
+    "--wrap=setBITSenderSerial,"
+    "--wrap=setBITSenderFramenum,"
+    "--wrap=sendToBITSender,"
+    "--wrap=testing_evtm"
+)
+
+# wrapping initBITSender
+# compiler will replace all calls to initBITSender with __wrap_initBITSender, and so on...
+set_property(TARGET test_evtm
+    PROPERTY
+        LINK_FLAGS
+            ${DEFAULT_LINK_FLAGS} ${LINK_FLAGS_WRAP})
+
+if (ENABLE_STYLE_CHECK)
+    check_style(test_evtm)
+endif()
+
+add_test(NAME evtm COMMAND test_evtm 1)
+
+# Run unit test upon build
+if (ENABLE_TESTS_ON_BUILD)
+    set(UNIT_TEST test_evtm)
+    add_custom_command(
+        TARGET ${UNIT_TEST}
+        COMMENT "Run test_evtm"
+        POST_BUILD
+        COMMAND ${UNIT_TEST}
+    )
+endif()

--- a/mcp/communications/tests/CMakeLists.txt
+++ b/mcp/communications/tests/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(test_evtm PRIVATE
     communications
 )
 
+# last element SHOULD NOT have a comma, else you will get a linker error
+# "/usr/bin/ld: cannot find : No such file or directory"
 string(CONCAT LINK_FLAGS_WRAP
     "-Wl,"
     "--wrap=initBITSender,"
@@ -25,7 +27,7 @@ string(CONCAT LINK_FLAGS_WRAP
     "--wrap=setBITSenderFramenum,"
     "--wrap=sendToBITSender,"
     "--wrap=testing_evtm,"
-    "--wrap=blast_fatal,"
+    "--wrap=bprintf"
 )
 
 # wrapping initBITSender

--- a/mcp/communications/tests/CMakeLists.txt
+++ b/mcp/communications/tests/CMakeLists.txt
@@ -24,7 +24,8 @@ string(CONCAT LINK_FLAGS_WRAP
     "--wrap=setBITSenderSerial,"
     "--wrap=setBITSenderFramenum,"
     "--wrap=sendToBITSender,"
-    "--wrap=testing_evtm"
+    "--wrap=testing_evtm,"
+    "--wrap=blast_fatal,"
 )
 
 # wrapping initBITSender

--- a/mcp/communications/tests/CMakeLists.txt
+++ b/mcp/communications/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ string(CONCAT LINK_FLAGS_WRAP
     "--wrap=setBITSenderSerial,"
     "--wrap=setBITSenderFramenum,"
     "--wrap=sendToBITSender,"
-    "--wrap=enable_EVTM_loop,"
+    "--wrap=EVTM_enable_loop,"
     "--wrap=bprintf"
 )
 

--- a/mcp/communications/tests/CMakeLists.txt
+++ b/mcp/communications/tests/CMakeLists.txt
@@ -26,7 +26,6 @@ string(CONCAT LINK_FLAGS_WRAP
     "--wrap=setBITSenderSerial,"
     "--wrap=setBITSenderFramenum,"
     "--wrap=sendToBITSender,"
-    "--wrap=EVTM_enable_loop,"
     "--wrap=bprintf"
 )
 

--- a/mcp/communications/tests/CMakeLists.txt
+++ b/mcp/communications/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ string(CONCAT LINK_FLAGS_WRAP
     "--wrap=setBITSenderSerial,"
     "--wrap=setBITSenderFramenum,"
     "--wrap=sendToBITSender,"
-    "--wrap=testing_evtm,"
+    "--wrap=enable_EVTM_loop,"
     "--wrap=bprintf"
 )
 

--- a/mcp/communications/tests/test_evtm.c
+++ b/mcp/communications/tests/test_evtm.c
@@ -35,24 +35,38 @@
 
 #include "evtm.c"
 #include "mcp_mock_decl.c"
+#include "blast.h"
+#include "channels_tng.h"
 
 // if compiler is invoked with --wrap=<func>, then the linker will resolve
 // <func> to __wrap_<func> instead of <func>.
 // this allows us to mock BITServer behavior.
 
-void * __wrap_blast_fatal(void *arg) {
-    check_expected(arg);
-    return mock_ptr_type(void *);
+void __wrap_bprintf(buos_t l, const char *fmt, ...) {
+    char message[BUOS_MAX];
+    va_list argptr;
+
+    va_start(argptr, fmt);
+    vsnprintf(message, BUOS_MAX, fmt, argptr);
+    va_end(argptr);
+
+    bputs(info, message);
+
+    if (l == fatal) {
+        check_expected(fmt);
+    }
 }
 
-int __wrap_initBITSender(struct BITServer *server, const char *addr, unsigned int port, \
-    unsigned int max_packet_size, unsigned int max_size, unsigned int max_queue_size) {
-    check_expected(server);
-    check_expected(addr);
+int __wrap_initBITSender(struct BITSender *server, const char *send_addr,
+  unsigned int port, unsigned int fifo_length, unsigned int fifo_maxsize, unsigned int packet_maxsize) {
+    assert_non_null(server);
+    assert_int_equal(fifo_length, FIFO_LEN);
+    assert_int_equal(fifo_maxsize, MAX(EVTM_MAX_SIZE, superframe->allframe_size*2));
+    assert_int_equal(packet_maxsize, EVTM_MAX_PACKET_SIZE);
+
+    check_expected(send_addr);
     check_expected(port);
-    check_expected(max_packet_size);
-    check_expected(max_size);
-    check_expected(max_queue_size);
+
     return mock_type(int);
 }
 
@@ -86,38 +100,16 @@ static int setup_EVTM(void **state) {
     // initialize the telemetries linklist
     // typically linklist_t are initialized in parse_linklist_format_opt
 
-    linklist_t LOS_LINKLIST = {
-        .name = "LOS",
-        .n_entries = 0,
-        .blk_size = 0,
-        .serial = NULL,
-        .items = NULL,
-        .flags = 0,
-        .blocks = NULL,
-        .num_blocks = 0,
-        .streams = NULL,
-        .num_streams = 0,
-        .internal_buffer = NULL,
-        .internal_id = 0,
-    };
+    channels_initialize(channel_list);
+    load_all_linklists(superframe, DEFAULT_LINKLIST_DIR, linklist_array, 0);
 
-    linklist_t TDRSS_LINKLIST = {
-        .name = "TDRSS",
-        .n_entries = 0,
-        .blk_size = 0,
-        .serial = NULL,
-        .items = NULL,
-        .flags = 0,
-        .blocks = NULL,
-        .num_blocks = 0,
-        .streams = NULL,
-        .num_streams = 0,
-        .internal_buffer = NULL,
-        .internal_id = 0,
-    };
+    // TODO(shubh): currently all linklists are set to the pilot linklist for testing purposes.
+    // THIS NEEDS TO BE CHANGED: CommandData.pilot_linklist_name -> CommandData.XXXX_linklist_name
+    telemetries_linklist[EVTM_LOS_TELEMETRY_INDEX] =
+        linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
+    telemetries_linklist[EVTM_TDRSS_TELEMETRY_INDEX] =
+        linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
 
-    telemetries_linklist[EVTM_LOS_TELEMETRY_INDEX] = &LOS_LINKLIST;
-    telemetries_linklist[EVTM_TDRSS_TELEMETRY_INDEX] = &TDRSS_LINKLIST;
     return 0;
 }
 
@@ -125,31 +117,25 @@ static int setup_EVTM(void **state) {
 /**
  * @brief test that setup_EVTM_config works for given EVTM telemetry type
  */
-void test_setup_EVTM_config(void **state, struct evtmType evtm_type, char *addr, int port, \
+void test_setup_EVTM_config(void **state, int evtm_type, char *addr, int port, \
                                 int telemetry_index, struct Fifo *evtm_fifo, char *name) {
     struct evtmSetup evtm_setup = {{0}};
     struct evtmInfo evtm_info = {.telemetries = telemetries_linklist, .evtm_type = evtm_type};
 
-    expect_value(__wrap_initBITServer, server, NULL);
-    expect_string(__wrap_initBITServer, addr, addr);
-    expect_value(__wrap_initBITServer, port, port);
-    expect_value(__wrap_initBITServer, max_packet_size, EVTM_MAX_PACKET_SIZE);
-    expect_value(__wrap_initBITServer, max_size, MAX(EVTM_MAX_SIZE, superframe->allframe_size*2));
-    expect_value(__wrap_initBITServer, max_queue_size, FIFO_LEN);
-    will_return(__wrap_initBITServer, 1);
+    expect_string(__wrap_initBITSender, send_addr, addr);
+    expect_value(__wrap_initBITSender, port, port);
+    will_return(__wrap_initBITSender, 1);
 
-    int rc = setup_EVTM_config(&evtm_info, &evtm_setup);
+    assert_int_equal(setup_EVTM_config(&evtm_info, &evtm_setup), 0);
 
-    assert_int_equal(rc, 0);
-    assert_non_null(evtm_setup);
+    assert_non_null(&evtm_setup);
     assert_int_equal(evtm_setup.evtm_type, evtm_type);
     assert_int_equal(evtm_setup.PORT, port);
     assert_ptr_equal(evtm_setup.telemetries, telemetries_linklist);
     assert_string_equal(evtm_setup.ADDR, addr);
-    assert_string_equal(evtm_setup.telemetries[telemetry_index]->name, name);
     assert_int_equal(evtm_setup.TELEMETRY_INDEX, telemetry_index);
     assert_int_equal(evtm_setup.fifosize, MAX(EVTM_MAX_SIZE, superframe->allframe_size*2));
-    assert_ptr_equal(evtm_setup.evtm_fifo, &evtm_fifo);
+    assert_ptr_equal(evtm_setup.evtm_fifo, evtm_fifo);
     assert_int_equal(evtm_setup.bandwidth, 0);
     assert_int_equal(evtm_setup.transmit_size, 0);
     assert_null(evtm_setup.ll);
@@ -165,7 +151,7 @@ void test_setup_EVTM_config(void **state, struct evtmType evtm_type, char *addr,
  */
 void test_setup_EVTM_config_LOS(void **state) {
     test_setup_EVTM_config(state, EVTM_LOS, EVTM_ADDR_LOS, EVTM_PORT_LOS, EVTM_LOS_TELEMETRY_INDEX, \
-                                evtm_fifo_los, "LOS");
+                                &evtm_fifo_los, "LOS");
 }
 
 /**
@@ -173,40 +159,32 @@ void test_setup_EVTM_config_LOS(void **state) {
  */
 void test_setup_EVTM_config_TDRSS(void **state) {
     test_setup_EVTM_config(state, EVTM_TDRSS, EVTM_ADDR_TDRSS, EVTM_PORT_TDRSS, EVTM_TDRSS_TELEMETRY_INDEX, \
-                                evtm_fifo_tdrss, "TDRSS");
+                                &evtm_fifo_tdrss, "TDRSS");
 }
 
 /**
  * @brief test that setup_EVTM_config fails gracefully for invalid telemetry type
  */
-void test_setup_EVTM_config_fails(void **state) { 
-    expect_string(__wrap_blast_fatal, arg, "Invalid evtm type 1511");
-    will_return(__wrap_blast_fatal, NULL);
-
+void test_setup_EVTM_config_fails(void **state) {
     struct evtmSetup evtm_setup = {{0}};
     struct evtmInfo evtm_info = {.telemetries = telemetries_linklist, .evtm_type = 1511};
-    setup_EVTM_config(&evtm_info, &evtm_setup);
+    expect_value(__wrap_bprintf, fmt, "%s:%d (%s):Invalid evtm type %d");
+    assert_int_equal(setup_EVTM_config(&evtm_info, &evtm_setup), -1);
 }
 
 /**
  * @brief test that setup_EVTM_config fails gracefully for invalid BITSender initialization
  */
 void test_setup_EVTM_config_fails_initBITSender(void **state) {
-    expect_string(__wrap_initBITServer, addr, EVTM_ADDR_LOS);
-    expect_value(__wrap_initBITServer, port, EVTM_PORT_LOS);
-    expect_value(__wrap_initBITServer, max_packet_size, EVTM_MAX_PACKET_SIZE);
-    expect_value(__wrap_initBITServer, max_size, MAX(EVTM_MAX_SIZE, superframe->allframe_size*2));
-    expect_value(__wrap_initBITServer, max_queue_size, FIFO_LEN);
-    will_return(__wrap_initBITServer, -1);
+    expect_string(__wrap_initBITSender, send_addr, EVTM_ADDR_LOS);
+    expect_value(__wrap_initBITSender, port, EVTM_PORT_LOS);
+    will_return(__wrap_initBITSender, -1);
 
-    char * err_msg = NULL;
-    asprintf(&err_msg, "initializing BITSender did not work for EVTM %s: check above error msg", EVTM_ADDR_LOS);
-    expect_string(__wrap_blast_fatal, arg, err_msg);
-    will_return(__wrap_blast_fatal, NULL);
-
-    struct evtmSetup evtm_setup = {{0}};
+    struct evtmSetup evtm_setup = {0};
     struct evtmInfo evtm_info = {.telemetries = telemetries_linklist, .evtm_type = EVTM_LOS};
-    setup_EVTM_config(&evtm_info, &evtm_setup);
+    expect_value(__wrap_bprintf, fmt, \
+        "%s:%d (%s):initializing BITSender did not work for EVTM %s: check above error msg");
+    assert_int_equal(setup_EVTM_config(&evtm_info, &evtm_setup), -1);
 }
 
 /**
@@ -217,7 +195,10 @@ void test_setup_EVTM_config_fails_initBITSender(void **state) {
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup(test_evtm_los, setup_EVTM),
+        cmocka_unit_test_setup_teardown(test_setup_EVTM_config_LOS, setup_EVTM, NULL),
+        cmocka_unit_test_setup_teardown(test_setup_EVTM_config_TDRSS, setup_EVTM, NULL),
+        cmocka_unit_test_setup_teardown(test_setup_EVTM_config_fails, setup_EVTM, NULL),
+        cmocka_unit_test_setup_teardown(test_setup_EVTM_config_fails_initBITSender, setup_EVTM, NULL),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/mcp/communications/tests/test_evtm.c
+++ b/mcp/communications/tests/test_evtm.c
@@ -1,0 +1,135 @@
+/**
+ * @file test_evtm.c
+ *
+ * @date September 21, 2023
+ * @author Shubh Agrawal
+ *
+ * @brief This file is part of MCP, created for the Terahertz Intensity Mapper (TIM) project.
+ *
+ * This software is copyright (C) 2023 University of Pennsylvania.
+ *
+ * MCP is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * MCP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MCP; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <cmocka.h>
+#include <float.h>
+#include <stdlib.h>
+#include <mcp.h>
+
+#include "evtm.c"
+#include "mcp_mock_decl.c"
+
+// if compiler is invoked with --wrap=<func>, then the linker will resolve
+// <func> to __wrap_<func> instead of <func>.
+// this allows us to mock BITServer behavior.
+
+int __wrap_initBITSender(struct BITServer *server, const char *addr, unsigned int port, \
+    unsigned int max_packet_size, unsigned int max_size, unsigned int max_queue_size) {
+    check_expected(server);
+    check_expected(addr);
+    check_expected(port);
+    check_expected(max_packet_size);
+    check_expected(max_size);
+    check_expected(max_queue_size);
+    return mock_type(int);
+}
+
+void __wrap_setBITSenderSerial(struct BITSender *sender, uint32_t serial) {
+    check_expected(sender);
+    check_expected(serial);
+}
+
+int __wrap_setBITSenderFramenum(struct BITSender *sender, uint32_t framenum) {
+    check_expected(sender);
+    check_expected(framenum);
+    return mock_type(int);
+}
+
+int __wrap_sendToBITSender(struct BITSender *sender, uint8_t *data, unsigned int size, uint8_t priority) {
+    check_expected(sender);
+    check_expected(data);
+    check_expected(size);
+    check_expected(priority);
+    return mock_type(int);
+}
+
+int __wrap_testing_evtm() {
+    return 1 // we are testing EVTM, this will result in the infinite loop not running
+}
+
+/**
+ * @brief Setup function to initialize the telemetries linklist, like in mcp.c
+ */
+static int setup_EVTM(void **state) {
+    // initialize the telemetries linklist
+    // load_all_linklists(superframe, DEFAULT_LINKLIST_DIR, linklist_array, 0);
+    // generate_housekeeping_linklist(linklist_find_by_name(ALL_TELEMETRY_NAME, linklist_array), ALL_TELEMETRY_NAME);
+    // linklist_generate_lookup(linklist_array);
+
+    // // TODO(shubh): currently all linklists are set to the pilot linklist for
+    // // testing purposes.
+    // // THIS NEEDS TO BE CHANGED: CommandData.pilot_linklist_name -> CommandData.XXXX_linklist_name
+
+    // // load the latest linklist into telemetry
+    // telemetries_linklist[PILOT_TELEMETRY_INDEX] =
+    //     linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
+    // telemetries_linklist[BI0_TELEMETRY_INDEX] =
+    //     linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
+    // telemetries_linklist[HIGHRATE_TELEMETRY_INDEX] =
+    //     linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
+    // telemetries_linklist[SBD_TELEMETRY_INDEX] =
+    //     linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
+    // telemetries_linklist[EVTM_LOS_TELEMETRY_INDEX] =
+    //     linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
+    // telemetries_linklist[EVTM_TDRSS_TELEMETRY_INDEX] =
+    //     linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
+
+    return 0;
+}
+
+
+/**
+ * @brief test that BITSender gets the correct inputs for Line of Sight EVTM
+ */
+void test_evtm_los(void **state) {
+    // struct evtmInfo evtm_info = {.telemetries = telemetries_linklist, .evtm_type = EVTM_LOS};
+    // expect_value(__wrap_initBITServer, server, NULL);
+    // expect_string(__wrap_initBITServer, addr, EVTM_ADDR_LOS);
+    // expect_value(__wrap_initBITServer, port, EVTM_PORT_LOS);
+    // expect_value(__wrap_initBITServer, max_packet_size, EVTM_MAX_PACKET_SIZE);
+    // expect_value(__wrap_initBITServer, max_size, MAX(EVTM_MAX_SIZE, superframe->allframe_size*2));
+    // expect_value(__wrap_initBITServer, max_queue_size, FIFO_LEN);
+    // will_return(__wrap_initBITServer, 1);
+
+    // expect_value(__wrap_setBITSenderSerial, sender, NULL);
+    // expect_value(__wrap_setBITSenderSerial, serial, \
+    //     *(uint32_t *) telemetries_linklist[EVTM_LOS_TELEMETRY_INDEX]->serial);
+
+    // expect_value(__wrap_setBITSenderFramenum, sender, NULL);
+    // expect_value(__wrap_setBITSenderFramenum, framenum, 0);
+}
+
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup(test_evtm_los, setup_EVTM),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/mcp/communications/tests/test_evtm.c
+++ b/mcp/communications/tests/test_evtm.c
@@ -97,10 +97,6 @@ int __wrap_sendToBITSender(struct BITSender *sender, uint8_t *data, unsigned int
     return mock_type(int);
 }
 
-int __wrap_EVTM_enable_loop() {
-    return 0; // we are testing EVTM, this will result in the infinite loop not running
-}
-
 /**
  * @brief gives a evtmSetup struct with the given parameters, similar to how the evtm.c function would
  */

--- a/mcp/include/mcp.h
+++ b/mcp/include/mcp.h
@@ -53,7 +53,7 @@ void force_incharge(void);
 // telemetry defines
 
 // how many options we have
-#define NUM_TELEMETRIES 4
+#define NUM_TELEMETRIES 6
 // iridium pilot index
 #define PILOT_TELEMETRY_INDEX 0
 // biphase index
@@ -62,6 +62,8 @@ void force_incharge(void);
 #define HIGHRATE_TELEMETRY_INDEX 2
 // science burst data index
 #define SBD_TELEMETRY_INDEX 3
+#define EVTM_LOS_TELEMETRY_INDEX 4
+#define EVTM_TDRSS_TELEMETRY_INDEX 5
 
 // Max Slew Veto (how long you can timeout slewing)
 #define VETO_MAX 60000

--- a/mcp/mcp.c
+++ b/mcp/mcp.c
@@ -531,8 +531,8 @@ blast_info("Finished initializing Beaglebones..."); */
   linklist_generate_lookup(linklist_array);
   ll_hk = linklist_find_by_name(ALL_TELEMETRY_NAME, linklist_array);
 
-  // TODO(shubh): currently all linklists are set to the pilot linklist for 
-  // testing purposes. 
+  // TODO(shubh): currently all linklists are set to the pilot linklist for
+  // testing purposes.
   // THIS NEEDS TO BE CHANGED: CommandData.pilot_linklist_name -> CommandData.XXXX_linklist_name
 
   // load the latest linklist into telemetry

--- a/mcp/mcp.c
+++ b/mcp/mcp.c
@@ -552,8 +552,8 @@ blast_info("Finished initializing Beaglebones..."); */
   struct evtmInfo evtm_tdrss_info = {.telemetries = telemetries_linklist, .evtm_type = EVTM_TDRSS};
   pthread_create(&pilot_send_worker, NULL, (void *) &pilot_compress_and_send, (void *) telemetries_linklist);
   pthread_create(&highrate_send_worker, NULL, (void *) &highrate_compress_and_send, (void *) telemetries_linklist);
-  pthread_create(&evtm_los_send_worker, NULL, (void *) &evtm_compress_and_send, (void *) &evtm_los_info);
-  pthread_create(&evtm_tdrss_send_worker, NULL, (void *) &evtm_compress_and_send, (void *) &evtm_tdrss_info);
+  pthread_create(&evtm_los_send_worker, NULL, (void *) &EVTM_compress_and_send, (void *) &evtm_los_info);
+  pthread_create(&evtm_tdrss_send_worker, NULL, (void *) &EVTM_compress_and_send, (void *) &evtm_tdrss_info);
   bi0_send_worker = ph_thread_spawn((void *) &biphase_writer, (void *) telemetries_linklist);
 
 

--- a/mcp/mcp.c
+++ b/mcp/mcp.c
@@ -531,8 +531,7 @@ blast_info("Finished initializing Beaglebones..."); */
   linklist_generate_lookup(linklist_array);
   ll_hk = linklist_find_by_name(ALL_TELEMETRY_NAME, linklist_array);
 
-  // TODO(shubh): currently all linklists are set to the pilot linklist for
-  // testing purposes.
+  // TODO(shubh): currently all linklists are set to the pilot linklist for testing purposes.
   // THIS NEEDS TO BE CHANGED: CommandData.pilot_linklist_name -> CommandData.XXXX_linklist_name
 
   // load the latest linklist into telemetry

--- a/mcp/mcp.c
+++ b/mcp/mcp.c
@@ -69,6 +69,7 @@
 #include "diskmanager_tng.h"
 #include "dsp1760.h"
 #include "ec_motors.h"
+#include "evtm.h"
 #include "framing.h"
 #include "gps.h"
 #include "linklist.h"
@@ -119,9 +120,11 @@ struct tm start_time;
 int ResetLog = 0;
 
 linklist_t * linklist_array[MAX_NUM_LINKLIST_FILES] = {NULL};
-linklist_t * telemetries_linklist[NUM_TELEMETRIES] = {NULL, NULL, NULL, NULL};
+linklist_t * telemetries_linklist[NUM_TELEMETRIES] = {NULL, NULL, NULL, NULL, NULL, NULL};
 uint8_t * master_superframe_buffer = NULL;
-struct Fifo * telem_fifo[NUM_TELEMETRIES] = {&pilot_fifo, &bi0_fifo, &highrate_fifo, &sbd_fifo};
+// struct Fifo * telem_fifo[NUM_TELEMETRIES] = {&pilot_fifo, &bi0_fifo, &highrate_fifo, &sbd_fifo};
+struct Fifo * telem_fifo[NUM_TELEMETRIES] = \
+                {&pilot_fifo, &bi0_fifo, &highrate_fifo, &sbd_fifo, &evtm_fifo_los, &evtm_fifo_tdrss};
 extern linklist_t * ll_hk;
 
 #define MPRINT_BUFFER_SIZE 1024
@@ -419,6 +422,8 @@ int main(int argc, char *argv[])
   pthread_t CommandDatacomm2;
   pthread_t CommandDataFIFO;
   pthread_t pilot_send_worker;
+  pthread_t evtm_los_send_worker;
+  pthread_t evtm_tdrss_send_worker;
   pthread_t highrate_send_worker;
   pthread_t CPU_monitor;
   int use_starcams = 0;
@@ -526,18 +531,30 @@ blast_info("Finished initializing Beaglebones..."); */
   linklist_generate_lookup(linklist_array);
   ll_hk = linklist_find_by_name(ALL_TELEMETRY_NAME, linklist_array);
 
+  // TODO(shubh): currently all linklists are set to the pilot linklist for 
+  // testing purposes. 
+  // THIS NEEDS TO BE CHANGED: CommandData.pilot_linklist_name -> CommandData.XXXX_linklist_name
+
   // load the latest linklist into telemetry
   telemetries_linklist[PILOT_TELEMETRY_INDEX] =
       linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
   telemetries_linklist[BI0_TELEMETRY_INDEX] =
-      linklist_find_by_name(CommandData.bi0_linklist_name, linklist_array);
+      linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
   telemetries_linklist[HIGHRATE_TELEMETRY_INDEX] =
-      linklist_find_by_name(CommandData.highrate_linklist_name, linklist_array);
+      linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
   telemetries_linklist[SBD_TELEMETRY_INDEX] =
-      linklist_find_by_name(CommandData.sbd_linklist_name, linklist_array);
+      linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
+  telemetries_linklist[EVTM_LOS_TELEMETRY_INDEX] =
+      linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
+  telemetries_linklist[EVTM_TDRSS_TELEMETRY_INDEX] =
+      linklist_find_by_name(CommandData.pilot_linklist_name, linklist_array);
 
+  struct evtmInfo evtm_los_info = {.telemetries = telemetries_linklist, .evtm_type = EVTM_LOS};
+  struct evtmInfo evtm_tdrss_info = {.telemetries = telemetries_linklist, .evtm_type = EVTM_TDRSS};
   pthread_create(&pilot_send_worker, NULL, (void *) &pilot_compress_and_send, (void *) telemetries_linklist);
   pthread_create(&highrate_send_worker, NULL, (void *) &highrate_compress_and_send, (void *) telemetries_linklist);
+  pthread_create(&evtm_los_send_worker, NULL, (void *) &evtm_compress_and_send, (void *) &evtm_los_info);
+  pthread_create(&evtm_tdrss_send_worker, NULL, (void *) &evtm_compress_and_send, (void *) &evtm_tdrss_info);
   bi0_send_worker = ph_thread_spawn((void *) &biphase_writer, (void *) telemetries_linklist);
 
 

--- a/mcp/testing/mcp_mock_decl.c
+++ b/mcp/testing/mcp_mock_decl.c
@@ -34,8 +34,9 @@
 int16_t SouthIAm = 0;
 int16_t InCharge = 1;
 int16_t InChargeSet = 0;
+#define NUM_TELEMETRIES 6
 linklist_t * linklist_array[MAX_NUM_LINKLIST_FILES] = {NULL};
-linklist_t * telemetries_linklist[NUM_TELEMETRIES] = {NULL, NULL, NULL, NULL};
+linklist_t * telemetries_linklist[NUM_TELEMETRIES] = {NULL, NULL, NULL, NULL, NULL, NULL}; // 6 telemetries
 int ResetLog = 0;
 time_t mcp_systime(time_t *t)
 {


### PR DESCRIPTION
MCP can send UDP multicast packets through the LOS/biphase and TDRSS/highrate EVTM downlinks. 

### Scope:

- changes made to `mcp` and related files.
- no changes yet for receiving ground software (`groundhog`).
- some sporadic non-exhaustive formatting changes to old code.
- exhaustive (?) test code for the new `evtm` code
- no changes for possible integration with code for Iridium Pilot

**Relevant Issue: #60** 

### Testing Reception At Ground Station:

1. _`iperf`_: Run `iperf -s -B 239.255.0.1 -u -i 1 -p 20001` and `iperf -s -B 239.255.0.1 -u -i 1 -p 20001`.
2. _`tcpdump`_: Run `sudo tcpdump` and see UDP packets sent to 239.255.0.1:20001 and 239.255.0.2:20002. 
3. _C code_: Compile [listener.c](https://github.com/tim-balloon/tim-logs/blob/main/telemetry/listener.c) and run `listener 239.255.0.1 20001` or `listener 239.255.0.2 20002` (_output will not be legible, but you should receive several packets_).

### TODOs for new GSs or FCs for testing:

1. _Turn off `ufw` firewall on the ground station: `sudo ufw disable`._ --> **OR BETTER OPTION: run `sudo ufw allow 20001/udp` and `sudo ufw allow 20001/udp` to get incoming UDP traffice on the relevent ports!**
2. On your flight computer, add a default gateway to the gondola network config in `/etc/netplan/00-installer-config.yaml`: 
&nbsp;  &nbsp;  `routes:`
&nbsp;  &nbsp;  &nbsp;  &nbsp;  `- to: default`
&nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp;  `via: 192.168.1.1`