### PR TITLE
EtherCAT motors enhancements

### DIFF
--- a/blast_config/derived.c
+++ b/blast_config/derived.c
@@ -299,7 +299,7 @@ derived_tng_t derived_list[] = {
     BITWORD("ST_AMP_OVER_T_EL", "status_el", 1, 1),
     BITWORD("ST_OVER_V_EL", "status_el", 2, 1),
     BITWORD("ST_UNDER_V_EL", "status_el", 3, 1),
-
+    BITWORD("ST_TEMP_SENS_ACTIVE_EL", "status_el", 4, 1),
     BITWORD("ST_FEEDBACK_ERR_EL", "status_el", 5, 1),
     BITWORD("ST_MOT_PHAS_ERR_EL", "status_el", 6, 1),
     BITWORD("ST_I_LIMITED_EL", "status_el", 7, 1),
@@ -325,12 +325,13 @@ derived_tng_t derived_list[] = {
     BITWORD("ST_IN_MOTION_EL", "status_el", 27, 1),
     BITWORD("ST_V_OUT_TRACK_W_EL", "status_el", 28, 1),
     BITWORD("ST_PHASE_NOT_INIT_EL", "status_el", 29, 1),
+    BITWORD("ST_CMD_FAULT_EL" , "status_el", 30, 1),
 
     BITWORD("ST_SHORT_CIRC_PIV", "status_piv", 0, 1),
     BITWORD("ST_AMP_OVER_T_PIV", "status_piv", 1, 1),
     BITWORD("ST_OVER_V_PIV", "status_piv", 2, 1),
     BITWORD("ST_UNDER_V_PIV", "status_piv", 3, 1),
-
+    BITWORD("ST_TEMP_SENS_ACTIVE_PIV", "status_piv", 4, 1),
     BITWORD("ST_FEEDBACK_ERR_PIV", "status_piv", 5, 1),
     BITWORD("ST_MOT_PHAS_ERR_PIV", "status_piv", 6, 1),
     BITWORD("ST_I_LIMITED_PIV", "status_piv", 7, 1),
@@ -356,12 +357,13 @@ derived_tng_t derived_list[] = {
     BITWORD("ST_IN_MOTION_PIV", "status_piv", 27, 1),
     BITWORD("ST_V_OUT_TRACK_W_PIV", "status_piv", 28, 1),
     BITWORD("ST_PHASE_NOT_INIT_PIV", "status_piv", 29, 1),
+    BITWORD("ST_CMD_FAULT_PIV" , "status_piv", 30, 1),
 
     BITWORD("ST_SHORT_CIRC_RW", "status_rw", 0, 1),
     BITWORD("ST_AMP_OVER_T_RW", "status_rw", 1, 1),
     BITWORD("ST_OVER_V_RW", "status_rw", 2, 1),
     BITWORD("ST_UNDER_V_RW", "status_rw", 3, 1),
-
+    BITWORD("ST_TEMP_SENS_ACTIVE_RW", "status_rw", 4, 1),
     BITWORD("ST_FEEDBACK_ERR_RW", "status_rw", 5, 1),
     BITWORD("ST_MOT_PHAS_ERR_RW", "status_rw", 6, 1),
     BITWORD("ST_I_LIMITED_RW", "status_rw", 7, 1),
@@ -387,6 +389,7 @@ derived_tng_t derived_list[] = {
     BITWORD("ST_IN_MOTION_RW", "status_rw", 27, 1),
     BITWORD("ST_V_OUT_TRACK_W_RW", "status_rw", 28, 1),
     BITWORD("ST_PHASE_NOT_INIT_RW", "status_rw", 29, 1),
+    BITWORD("ST_CMD_FAULT_RW" , "status_rw", 30, 1),
     BITWORD("NET_ST_NODE_STATUS_RW", "network_status_rw", 0, 2),
     BITWORD("NET_ST_SYNC_MISSING_RW", "network_status_rw", 4, 1),
     BITWORD("NET_ST_GUARD_ERR_RW", "network_status_rw", 5, 1),

--- a/blast_config/tx_struct_tng.c
+++ b/blast_config/tx_struct_tng.c
@@ -81,11 +81,11 @@ channel_t channel_list[] =
     /*---------------------------------------------------------------------------------------*/
 
     // EtherCat Status Info
-    { "n_found_ec",         SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
-    { "slave_count_ec",         SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
-    { "status_ec",         SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
+    { "n_found_ec",           SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
+    { "periph_count_ec",      SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
+    { "status_ec",            SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
     { "status_ec_rw",         SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
-    { "status_ec_piv",         SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
+    { "status_ec_piv",        SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
     { "status_ec_el",         SCALE(CONVERT_UNITY), TYPE_UINT8, RATE_1HZ, U_NONE, 0 },
 
     // Overall MC Az/El variables (mixed pivot+rw and el)

--- a/mcp/include/ec_motors.h
+++ b/mcp/include/ec_motors.h
@@ -162,7 +162,7 @@ typedef struct {
     uint8_t is_mc;
     uint8_t comms_ok;
     uint8_t has_dc;
-    uint8_t slave_error;
+    uint8_t periph_error;
     uint16_t network_error_count;
     ec_control_status_t status;
 } ec_device_state_t;
@@ -173,10 +173,10 @@ typedef struct {
  * 
  */
 typedef struct {
-	int8_t n_found;
-	int8_t slave_count;
-	uint16_t network_error_count;
-	ec_control_status_t status;
+    int8_t n_found;
+    int8_t periph_count;
+    uint16_t network_error_count;
+    ec_control_status_t status;
 } ec_state_t;
 
 #define COPLEY_ETHERCAT_VENDOR 0x000000ab

--- a/mcp/include/ec_motors.h
+++ b/mcp/include/ec_motors.h
@@ -36,6 +36,10 @@
     _map.index = _index;\
     _map.subindex = _subindex;\
 }
+// Current loop tuning coefficients are generally determined from Copley
+// tuning software (CME2) or manual tuning of response curve of commanded
+// current/achieved current vs. time. They will need to be updated for each new
+// motor/drive pairing.
 // reaction wheel P.I.(D.) coefficients
 #define RW_DEFAULT_CURRENT_P    20000
 #define RW_DEFAULT_CURRENT_I    200

--- a/mcp/include/ec_motors.h
+++ b/mcp/include/ec_motors.h
@@ -70,6 +70,12 @@
 #define ECAT_RXPDO_MAPPING 0x1600
 
 #define ECAT_DC_CYCLE_NS 1000000 /* Distributed Clock Cycle in nanoseconds */
+#define EC_TIMEOUTMON 500 // Timeout for peripheral recovery and reconfig, microseconds
+#ifndef EC_STATE_NONE
+// Older versions of SOEM don't provide this, but it's useful for recovering
+// lost drives
+#define EC_STATE_NONE 0x00
+#endif
 
 
 /**

--- a/mcp/include/ec_motors.h
+++ b/mcp/include/ec_motors.h
@@ -37,8 +37,8 @@
     _map.subindex = _subindex;\
 }
 // reaction wheel P.I.(D.) coefficients
-#define RW_DEFAULT_CURRENT_P    1500
-#define RW_DEFAULT_CURRENT_I    45
+#define RW_DEFAULT_CURRENT_P    20000
+#define RW_DEFAULT_CURRENT_I    200
 #define RW_DEFAULT_CURRENT_OFF  (0)
 // elevation drive P.I.(D.) coefficients
 #define EL_DEFAULT_CURRENT_P    4126

--- a/mcp/include/motors.h
+++ b/mcp/include/motors.h
@@ -84,6 +84,7 @@ typedef struct
     uint16_t network_status;      // network status
     uint32_t fault_reg;           // drive fault register
     uint16_t ALstatuscode;        // EtherCAT application layer status code (see ETG.1000)
+    uint16_t ALstate;             // EtherCAT state machine state (see ETG.1000)
     uint16_t drive_info;          // motorinfo struct
     uint16_t control_word_read;   // commanded state read back from controller
     uint16_t control_word_write;  // commanded state

--- a/mcp/include/motors.h
+++ b/mcp/include/motors.h
@@ -83,6 +83,7 @@ typedef struct
     uint32_t status;              // drive status
     uint16_t network_status;      // network status
     uint32_t fault_reg;           // drive fault register
+    uint16_t ALstatuscode;        // EtherCAT application layer status code (see ETG.1000)
     uint16_t drive_info;          // motorinfo struct
     uint16_t control_word_read;   // commanded state read back from controller
     uint16_t control_word_write;  // commanded state

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -71,7 +71,7 @@ ec_slavet* ec_periph = ec_slave;
 #define N_MCs 4
 
 // device node Serial Numbers
-#define RW_SN 0x01bbbb65
+#define RW_SN 0x35f4cc0d // 0x01bbbb65
 #define PIV_SN 0x02924687
 #define EL_SN 0x01238408
 // addresses on the EC network
@@ -1060,33 +1060,30 @@ void rw_init_phasing(void)
 
 /**
  * Sets the current limits for the RW motor.
- * TODO(evanmayer): Update the current limits for each motor controller/motor pair
  */
 void rw_init_current_limit(void)
 {
     if (rw_index) {
-        ec_SDOwrite16(rw_index, 0x2110, 0, 3600);   // 36 Amps peak current limit
-        ec_SDOwrite16(rw_index, 0x2111, 0, 1200);   // 12 Amps continuous current limit
+        ec_SDOwrite16(rw_index, 0x2110, 0, 3000);   // 30 Amps peak current limit
+        ec_SDOwrite16(rw_index, 0x2111, 0, 1500);   // 15 Amps continuous current limit
     }
 }
 
 
 /**
  * Sets the current limits for the elevation motor.
- * TODO(evanmayer): Update the current limits for each motor controller/motor pair
  */
 void el_init_current_limit(void)
 {
     if (el_index) {
-        ec_SDOwrite16(el_index, 0x2110, 0, 3600);   // 36 Amps peak current limit
-        ec_SDOwrite16(el_index, 0x2111, 0, 1200);    // 12 Amps continuous current limit
+        ec_SDOwrite16(el_index, 0x2110, 0, 3000);   // 30 Amps peak current limit
+        ec_SDOwrite16(el_index, 0x2111, 0, 1500);   // 15 Amps continuous current limit
     }
 }
 
 
 /**
  * Sets the current limits for the pivot motor.
- * TODO(evanmayer): Update the current limits for each motor controller/motor pair
  */
 void piv_init_current_limit(void)
 {
@@ -2110,7 +2107,7 @@ static void* motor_control(void* arg)
     struct timespec ts;
     struct timespec interval_ts = { .tv_sec = 0,
                                     .tv_nsec = 2000000}; /// 500HZ interval
-    char name[16] = "eth1";
+    char name[16] = "enp1s0";
 	bool firsttime = 1;
 
     nameThread("Motors");

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -501,7 +501,7 @@ uint16_t rw_get_ALstatuscode(void) {
 
 
 /**
- * @brief Wrapper of get_ALstatuscode() for reaction wheel.
+ * @brief Wrapper of get_ALstatuscode() for elevation axis.
  * 
  * @return Value of peripheral's 0x0134 register
  */
@@ -511,12 +511,60 @@ uint16_t el_get_ALstatuscode(void) {
 
 
 /**
- * @brief Wrapper of get_ALstatuscode() for reaction wheel.
+ * @brief Wrapper of get_ALstatuscode() for pivot.
  * 
  * @return Value of peripheral's 0x0134 register
  */
 uint16_t piv_get_ALstatuscode(void) {
     return get_ALstatuscode(piv_index);
+}
+
+
+/**
+ * @brief Returns the hex value of the EtherCAT state machine (ESM).
+ * 
+ * @details Ref. ETG.1000 Part 6, Sec. 6.4.1, ETG.1300 Table 8. The EtherCAT
+ * application layer (AL) state machine coordinates communication and
+ * synchronization of the controller and peripheral devices during start up
+ * and operation. It is the peripheral device's register 0x0130.
+ * 
+ * @param[in] m_index The motor controller to talk to
+ * @return Value of peripheral's 0x0130 register
+ */
+uint16_t get_ALstate(int m_index) {
+    // Ensure peripherals' state struct is up to date
+    ec_readstate();
+    return ec_periph[m_index].state;
+}
+
+
+/**
+ * @brief Wrapper of get_ALstate() for reaction wheel.
+ * 
+ * @return Value of peripheral's 0x0130 register, EtherCAT state
+ */
+uint16_t rw_get_ALstate(void) {
+    return get_ALstate(rw_index);
+}
+
+
+/**
+ * @brief Wrapper of get_ALstate() for elevation axis.
+ * 
+ * @return Value of peripheral's 0x0130 register, EtherCAT state
+ */
+uint16_t el_get_ALstate(void) {
+    return get_ALstate(el_index);
+}
+
+
+/**
+ * @brief Wrapper of get_ALstate() for pivot.
+ * 
+ * @return Value of peripheral's 0x0130 register, EtherCAT state
+ */
+uint16_t piv_get_ALstate(void) {
+    return get_ALstate(piv_index);
 }
 
 
@@ -1895,6 +1943,7 @@ static void read_motor_data()
     RWMotorData[motor_i].drive_info = rw_get_status_word();
     RWMotorData[motor_i].fault_reg = rw_get_latched();
     RWMotorData[motor_i].ALstatuscode = rw_get_ALstatuscode();
+    RWMotorData[motor_i].ALstate = rw_get_ALstate();
     RWMotorData[motor_i].status = rw_get_status_register();
     RWMotorData[motor_i].network_status = rw_get_network_status_word();
     RWMotorData[motor_i].position = rw_get_position();
@@ -1911,6 +1960,7 @@ static void read_motor_data()
     ElevMotorData[motor_i].drive_info = el_get_status_word();
     ElevMotorData[motor_i].fault_reg = el_get_latched();
     ElevMotorData[motor_i].ALstatuscode = el_get_ALstatuscode();
+    ElevMotorData[motor_i].ALstate = el_get_ALstate();
     ElevMotorData[motor_i].status = el_get_status_register();
     ElevMotorData[motor_i].network_status = el_get_network_status_word();
     ElevMotorData[motor_i].position = el_get_position();
@@ -1927,6 +1977,7 @@ static void read_motor_data()
     PivotMotorData[motor_i].drive_info = piv_get_status_word();
     PivotMotorData[motor_i].fault_reg = piv_get_latched();
     PivotMotorData[motor_i].ALstatuscode = piv_get_ALstatuscode();
+    PivotMotorData[motor_i].ALstate = piv_get_ALstate();
     PivotMotorData[motor_i].status = piv_get_status_register();
     PivotMotorData[motor_i].network_status = piv_get_network_status_word();
     PivotMotorData[motor_i].position = piv_get_position();

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -1219,7 +1219,7 @@ static int find_controllers(void)
         ec_readstate();
         for (int i = 1; i <= ec_periphcount; i++) {
             if (ec_periph[i].state != EC_STATE_SAFE_OP) {
-                blast_err("Peripheral %d State=%2x StatusCode=%4x : %s", i, ec_periph[i].state,
+                blast_err("Peripheral %d State=0x%.1x StatusCode=0x%.4x : %s", i, ec_periph[i].state,
                         ec_periph[i].ALstatuscode, ec_ALstatuscode2string(ec_periph[i].ALstatuscode));
             }
         }
@@ -1237,28 +1237,28 @@ static int find_controllers(void)
         int size = 4;
         ec_SDOread(i, 0x2384, 1, false, &size, &serial, EC_TIMEOUTRXM);
         if (serial == RW_SN) {
-            blast_startup("Reaction Wheel Motor Controller %d: %s: SN: %4x",
+            blast_startup("Reaction Wheel Motor Controller %d: %s: SN: 0x%.4x",
                           ec_periph[i].aliasadr, ec_periph[i].name, serial);
             rw_index = i;
             blast_info("Setting rw_index to %d", rw_index);
             blast_info("ec_periph[%d].outputs = %p", i, ec_periph[i].outputs);
            controller_state[i].is_mc = 1;
         } else if (serial == PIV_SN) {
-            blast_startup("Pivot Motor Controller %d: %s: SN: %4x",
+            blast_startup("Pivot Motor Controller %d: %s: SN: 0x%.4x",
                           ec_periph[i].aliasadr, ec_periph[i].name, serial);
             piv_index = i;
             blast_info("Setting piv_index to %d", piv_index);
             blast_info("ec_periph[%d].outputs = %p", i, ec_periph[i].outputs);
             controller_state[i].is_mc = 1;
         } else if (serial == EL_SN) {
-            blast_startup("Elevation Motor Controller %d: %s: SN: %4x",
+            blast_startup("Elevation Motor Controller %d: %s: SN: 0x%.4x",
                           ec_periph[i].aliasadr, ec_periph[i].name, serial);
             el_index = i;
             controller_state[i].is_mc = 1;
             blast_info("Setting el_index to %d", el_index);
             blast_info("ec_periph[%d].outputs = %p", i, ec_periph[i].outputs);
         } else {
-            blast_warn("Got unknown MC %s at position %d with serial %#4x and alias %d",
+            blast_warn("Got unknown MC %s at position %d with serial 0x%.4x and alias %d",
                        ec_periph[i].name, ec_periph[i].configadr, serial, ec_periph[i].aliasadr);
             controller_state[i].ec_unknown = 1;
         }
@@ -1530,7 +1530,7 @@ static void map_index_vars(int m_index)
         } \
     } \
     if (!found) { \
-        blast_err("Could not find PDO map for index %d channel index = %2x, subindex = %d", \
+        blast_err("Could not find PDO map for index %d channel index = 0x%.2x, subindex = %d", \
                    m_index, object_index(_obj),  object_subindex(_obj)); \
     } \
     }
@@ -1682,7 +1682,7 @@ static int motor_set_operational(void)
      */
     for (int i = 1; i <= ec_periphcount; i++) {
         if (ec_periph[i].state != EC_STATE_OPERATIONAL) {
-            blast_err("Peripheral %d State=%2x StatusCode=%4x : %s", i, ec_periph[i].state,
+            blast_err("Peripheral %d State=0x%.1x StatusCode=0x%.4x : %s", i, ec_periph[i].state,
                     ec_periph[i].ALstatuscode, ec_ALstatuscode2string(ec_periph[i].ALstatuscode));
         }
     }
@@ -1735,7 +1735,7 @@ static uint8_t check_ec_ready(int index)
 static uint8_t check_for_network_problem(uint16_t net_status, bool firsttime)
 {
     if (firsttime) {
-        blast_info("net_status = %2x", net_status);
+        blast_info("net_status = 0x%.2x", net_status);
     }
     // Device is not in operational mode (bits 0 and 1 have value of 3)
     if (!(net_status & ECAT_NET_NODE_CHECK)) {
@@ -1872,7 +1872,7 @@ void mc_readPDOassign(int m_periph) {
     wkc = ec_SDOread(m_periph, ECAT_TXPDO_ASSIGNMENT, 0x00, FALSE, &len, &rdat, EC_TIMEOUTRXM);
     rdat = etohs(rdat);
     /* positive result from peripheral ? */
-    blast_info("Result from ec_SDOread at index %04x, wkc = %i, len = %i, rdat = %04x",
+    blast_info("Result from ec_SDOread at index 0x%.4x, wkc = %i, len = %i, rdat = 0x%.4x",
                ECAT_TXPDO_ASSIGNMENT, wkc, len, rdat);
     if ((wkc <= 0) || (rdat <= 0))  {
     	blast_info("no data returned from ec_SDOread ... returning.");
@@ -1892,7 +1892,7 @@ void mc_readPDOassign(int m_periph) {
         if (idx <= 0) {
         	continue;
         } else {
-//            blast_info("found idx = %2x at wkc = %i, idxloop = %i", idx, wkc, idxloop);
+//            blast_info("found idx = 0x%.2x at wkc = %i, idxloop = %i", idx, wkc, idxloop);
         }
         len = sizeof(subcnt);
         subcnt = 0;
@@ -1914,7 +1914,7 @@ void mc_readPDOassign(int m_periph) {
             channel->offset = offset;
             pdo_list[m_periph] = g_slist_prepend(pdo_list[m_periph], channel);
 //            blast_info("Read SDO subidxloop = %i, wkc = %i, idx = %i, len = %i", subidxloop, wkc, idx, len);
-//            blast_info("Appending channel to m_pdo_list = %p: index = %2x, subindex = %i, offset = %i",
+//            blast_info("Appending channel to m_pdo_list = %p: index = 0x%.2x, subindex = %i, offset = %i",
 //                       pdo_list[m_periph], channel->index, channel->subindex, channel->offset);
 
             /// Offset is the number of bytes into the memory map this element is.  First element is 0 bytes in.

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -131,36 +131,32 @@ static int32_t dummy_var = 0;
 static int32_t dummy_write_var = 0;
 
 /// Read words
-static int32_t *motor_position[N_MCs] = { &dummy_var, &dummy_var, &dummy_var , &dummy_var , &dummy_var };
-static int32_t *motor_velocity[N_MCs] = { &dummy_var, &dummy_var, &dummy_var , &dummy_var , &dummy_var };
-static int32_t *actual_position[N_MCs] = { &dummy_var, &dummy_var, &dummy_var, &dummy_var , &dummy_var };
+static int32_t *motor_position[N_MCs] = { &dummy_var, &dummy_var, &dummy_var , &dummy_var };
+static int32_t *motor_velocity[N_MCs] = { &dummy_var, &dummy_var, &dummy_var , &dummy_var };
+static int32_t *actual_position[N_MCs] = { &dummy_var, &dummy_var, &dummy_var, &dummy_var };
 static int16_t *motor_current[N_MCs] = { (int16_t*) &dummy_var, (int16_t*) &dummy_var,
-                                         (int16_t*) &dummy_var, (int16_t*) &dummy_var , (int16_t*) &dummy_var };
+                                         (int16_t*) &dummy_var, (int16_t*) &dummy_var };
 static uint32_t *status_register[N_MCs] = { (uint32_t*) &dummy_var, (uint32_t*) &dummy_var,
-                                            (uint32_t*) &dummy_var, (uint32_t*) &dummy_var , (uint32_t*) &dummy_var };
+                                            (uint32_t*) &dummy_var, (uint32_t*) &dummy_var };
 static int16_t *amp_temp[N_MCs] = { (int16_t*) &dummy_var, (int16_t*) &dummy_var,
                                     (int16_t*) &dummy_var, (int16_t*) &dummy_var };
 static uint16_t *status_word[N_MCs] = { (uint16_t*) &dummy_var, (uint16_t*) &dummy_var,
-                                        (uint16_t*) &dummy_var, (uint16_t*) &dummy_var , (uint16_t*) &dummy_var };
+                                        (uint16_t*) &dummy_var, (uint16_t*) &dummy_var };
 static uint16_t *network_status_word[N_MCs] = { (uint16_t*) &dummy_var, (uint16_t*) &dummy_var,
-                                        (uint16_t*) &dummy_var, (uint16_t*) &dummy_var , (uint16_t*) &dummy_var };
+                                                (uint16_t*) &dummy_var, (uint16_t*) &dummy_var };
 static uint32_t *latched_register[N_MCs] = { (uint32_t*) &dummy_var, (uint32_t*) &dummy_var,
-                                             (uint32_t*) &dummy_var, (uint32_t*) &dummy_var , (uint32_t*) &dummy_var };
+                                             (uint32_t*) &dummy_var, (uint32_t*) &dummy_var };
 static uint16_t *control_word_read[N_MCs] = { (uint16_t*) &dummy_var, (uint16_t*) &dummy_var,
-                                              (uint16_t*) &dummy_var, (uint16_t*) &dummy_var , (uint16_t*) &dummy_var };
+                                              (uint16_t*) &dummy_var, (uint16_t*) &dummy_var };
 static int16_t *phase_angle[N_MCs] = { (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var,
-                                          (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var ,
-                                          (int16_t*) &dummy_write_var };
+                                       (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var };
 static uint16_t *phase_mode[N_MCs] = { (uint16_t*) &dummy_write_var, (uint16_t*) &dummy_write_var,
-                                          (uint16_t*) &dummy_write_var, (uint16_t*) &dummy_write_var ,
-                                          (uint16_t*) &dummy_write_var };
+                                       (uint16_t*) &dummy_write_var, (uint16_t*) &dummy_write_var };
 /// Write words
 static uint16_t *control_word[N_MCs] = { (uint16_t*) &dummy_write_var, (uint16_t*) &dummy_write_var,
-                                         (uint16_t*) &dummy_write_var, (uint16_t*) &dummy_write_var ,
-                                         (uint16_t*) &dummy_write_var };
+                                         (uint16_t*) &dummy_write_var, (uint16_t*) &dummy_write_var };
 static int16_t *target_current[N_MCs] = { (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var,
-                                          (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var ,
-                                          (int16_t*) &dummy_write_var };
+                                          (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var };
 // static int16_t *latched_register_writable[N_MCs] = { (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var,
 //                                                      (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var ,
 //                                                      (int16_t*) &dummy_write_var };

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -175,9 +175,6 @@ static uint16_t *control_word[N_MCs] = { (uint16_t*) &dummy_write_var, (uint16_t
                                          (uint16_t*) &dummy_write_var, (uint16_t*) &dummy_write_var };
 static int16_t *target_current[N_MCs] = { (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var,
                                           (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var };
-// static int16_t *latched_register_writable[N_MCs] = { (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var,
-//                                                      (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var ,
-//                                                      (int16_t*) &dummy_write_var };
 
 
 
@@ -1736,7 +1733,6 @@ static void map_index_vars(int m_index)
     if (controller_state[m_index].is_mc) {
         control_word[m_index] = (uint16_t*) (ec_periph[m_index].outputs);
         target_current[m_index] = (int16_t*) (control_word[m_index] + 1);
-        // latched_register_writable[m_index] = (int16_t*) (control_word[m_index] + 2);
         if (!(ec_periph[m_index].outputs)) {
             blast_err("Error: IOmap was not configured correctly!"
                 "Setting periph_error = 1 for peripheral %d...", m_index);
@@ -2175,7 +2171,6 @@ int configure_ec_motors()
     for (int i = 1; i <= ec_periphcount; i++) {
         if ((controller_state[i].is_mc) && !(controller_state[i].periph_error)) {
             *target_current[i] = 0;
-            // *latched_register_writable[i] = 0xFFFFFFFF; // ECAT_FAULT_CMD_LOST;
             *control_word[i] = ECAT_CTL_ON | ECAT_CTL_ENABLE_VOLTAGE | ECAT_CTL_QUICK_STOP| ECAT_CTL_ENABLE;
         }
     }
@@ -2394,7 +2389,6 @@ OSAL_THREAD_FUNC ecatcheck(void)
  */
 static void* motor_control(void* arg)
 {
-    int wkc;
     int ret;
     struct timespec ts;
     struct timespec interval_ts = { .tv_sec = 0,
@@ -2542,7 +2536,9 @@ int initialize_motors(void)
 uint8_t make_ec_status_field(int m_index)
 {
     uint8_t m_stats = 0;
-    if ((m_index < 1) || (m_index >= N_MCs)) return m_stats;
+    if ((m_index < 1) || (m_index >= N_MCs)) {
+        return m_stats;
+    }
     m_stats |= (m_index & 0x07);
     m_stats |= ((controller_state[m_index].comms_ok & 0x01) << 3);
     m_stats |= ((controller_state[m_index].periph_error & 0x01) << 4);

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -2075,7 +2075,9 @@ int configure_ec_motors()
         }
     }
     // If things seem to be working then we don't need to recommutate the RW.
-    if (controller_state[rw_index].comms_ok) CommandData.ec_devices.have_commutated_rw = 1;
+    if (controller_state[rw_index].comms_ok) {
+        CommandData.ec_devices.have_commutated_rw = 1;
+    }
     return(1);
 }
 
@@ -2205,7 +2207,9 @@ static void* motor_control(void* arg)
             }
         }
         if (CommandData.ec_devices.reset) {
-            if (!reset_ec_motors()) blast_err("Reset of EtherCat devices failed!");
+            if (!reset_ec_motors()) {
+                blast_err("Reset of EtherCat devices failed!");
+            }
             CommandData.ec_devices.reset = 0;
         }
         if (!CommandData.ec_devices.have_commutated_rw) {

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -59,7 +59,7 @@ static ph_thread_t *ecmonitor_ctl_id;
 extern int16_t InCharge;
 
 #define ECAT_SENDRECV_STACKSIZE (64 * 1024)
-int ecat_sendrecv_cadence_us = 2000000;
+int ecat_sendrecv_cadence_ns = 2000000;
 pthread_t ecat_sendrecv_thread;
 pthread_t ecat_check_thread;
 // We require some globals here to keep track of state between threads for
@@ -2293,7 +2293,7 @@ void shutdown_motors(void)
 OSAL_THREAD_FUNC_RT motor_send_recv(void) {
     struct timespec ts;
     struct timespec interval_ts = { .tv_sec = 0,
-                                    .tv_nsec = ecat_sendrecv_cadence_us}; /// 500HZ interval
+                                    .tv_nsec = ecat_sendrecv_cadence_ns}; /// 500HZ interval
     int ret = 0;
 
     nameThread("Motors send/recv");

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -58,6 +58,12 @@ static ph_thread_t *ecmonitor_ctl_id;
 
 extern int16_t InCharge;
 
+// Intentional aliasing
+int* p_ec_periphcount = &ec_slavecount;
+#define ec_periphcount (*p_ec_periphcount)
+ec_slavet* ec_periph = ec_slave;
+#define ec_periph (ec_periph)
+
 /**
  * @brief Number of ethercat controllers
  * If you change this, also change EC_MAXSLAVE in ethercatmain.h
@@ -90,7 +96,7 @@ static GSList *pdo_list[N_MCs];
 
 
 /**
- * @brief Index numbers for the slave array.  0 is the master (flight computer)
+ * @brief Index numbers for the peripheral array.  0 is the master (flight computer)
  * These are set by the find_controllers function that is run when we start up the network
  */
 static int rw_index = 0;
@@ -164,7 +170,7 @@ static int16_t *target_current[N_MCs] = { (int16_t*) &dummy_write_var, (int16_t*
  * @param m_index motor controller to talk to
  * @return int 0 on failure or 1 on success
  */
-int check_slave_comm_ready(int m_index) {
+int check_peripheral_comm_ready(int m_index) {
     if (m_index < 1) {
         return 0; // m_index must be > 0
     }
@@ -183,7 +189,7 @@ int check_slave_comm_ready(int m_index) {
  */
 uint32_t rw_get_latched(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *latched_register[rw_index];
     } else {
         return 0;
@@ -198,7 +204,7 @@ uint32_t rw_get_latched(void)
  */
 uint32_t el_get_latched(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *latched_register[el_index];
     } else {
         return 0;
@@ -213,7 +219,7 @@ uint32_t el_get_latched(void)
  */
 uint32_t piv_get_latched(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *latched_register[piv_index];
     } else {
         return 0;
@@ -228,7 +234,7 @@ uint32_t piv_get_latched(void)
  */
 uint16_t rw_get_ctl_word(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *control_word_read[rw_index];
     } else {
         return 0;
@@ -243,7 +249,7 @@ uint16_t rw_get_ctl_word(void)
  */
 uint16_t el_get_ctl_word(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *control_word_read[el_index];
     } else {
         return 0;
@@ -258,7 +264,7 @@ uint16_t el_get_ctl_word(void)
  */
 uint16_t piv_get_ctl_word(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *control_word_read[piv_index];
     } else {
         return 0;
@@ -273,7 +279,7 @@ uint16_t piv_get_ctl_word(void)
  */
 int16_t piv_get_phase_angle(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *phase_angle[piv_index];
     } else {
         return 0;
@@ -288,7 +294,7 @@ int16_t piv_get_phase_angle(void)
  */
 int16_t rw_get_phase_angle(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *phase_angle[rw_index];
     } else {
         return 0;
@@ -303,7 +309,7 @@ int16_t rw_get_phase_angle(void)
  */
 int16_t el_get_phase_angle(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *phase_angle[el_index];
     } else {
         return 0;
@@ -318,7 +324,7 @@ int16_t el_get_phase_angle(void)
  */
 uint16_t piv_get_phase_mode(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *phase_mode[piv_index];
     } else {
         return 0;
@@ -333,7 +339,7 @@ uint16_t piv_get_phase_mode(void)
  */
 uint16_t rw_get_phase_mode(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *phase_mode[rw_index];
     } else {
         return 0;
@@ -348,7 +354,7 @@ uint16_t rw_get_phase_mode(void)
  */
 uint16_t el_get_phase_mode(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *phase_mode[el_index];
     } else {
         return 0;
@@ -363,7 +369,7 @@ uint16_t el_get_phase_mode(void)
  */
 uint16_t rw_get_ctl_word_write(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *control_word[rw_index];
     } else {
         return 0;
@@ -378,7 +384,7 @@ uint16_t rw_get_ctl_word_write(void)
  */
 uint16_t el_get_ctl_word_write(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *control_word[el_index];
     } else {
         return 0;
@@ -393,7 +399,7 @@ uint16_t el_get_ctl_word_write(void)
  */
 uint16_t piv_get_ctl_word_write(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *control_word[piv_index];
     } else {
         return 0;
@@ -408,7 +414,7 @@ uint16_t piv_get_ctl_word_write(void)
  */
 uint16_t rw_get_network_status_word(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *network_status_word[rw_index];
     } else {
         return 0;
@@ -423,7 +429,7 @@ uint16_t rw_get_network_status_word(void)
  */
 uint16_t el_get_network_status_word(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *network_status_word[el_index];
     } else {
         return 0;
@@ -438,7 +444,7 @@ uint16_t el_get_network_status_word(void)
  */
 uint16_t piv_get_network_status_word(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *network_status_word[piv_index];
     } else {
         return 0;
@@ -453,7 +459,7 @@ uint16_t piv_get_network_status_word(void)
  */
 int32_t rw_get_position(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *actual_position[rw_index];
     } else {
         return 0;
@@ -468,7 +474,7 @@ int32_t rw_get_position(void)
  */
 int32_t el_get_position(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *actual_position[el_index];
     } else {
         return 0;
@@ -484,7 +490,7 @@ int32_t el_get_position(void)
  */
 int32_t el_get_motor_position(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *motor_position[el_index] + ENC_RAW_EL_OFFSET/EL_MOTOR_ENCODER_SCALING;
     } else {
         return 0;
@@ -499,7 +505,7 @@ int32_t el_get_motor_position(void)
  */
 int32_t piv_get_position(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *actual_position[piv_index];
     } else {
         return 0;
@@ -514,7 +520,7 @@ int32_t piv_get_position(void)
  */
 double rw_get_position_degrees(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return rw_get_position() * RW_ENCODER_SCALING;
     } else {
         return 0;
@@ -530,7 +536,7 @@ double rw_get_position_degrees(void)
  */
 double el_get_position_degrees(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return el_get_position() * EL_LOAD_ENCODER_SCALING;
     } else {
         return 0;
@@ -546,7 +552,7 @@ double el_get_position_degrees(void)
  */
 double el_get_motor_position_degrees(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return el_get_motor_position() * EL_MOTOR_ENCODER_SCALING;
     } else {
         return 0;
@@ -561,7 +567,7 @@ double el_get_motor_position_degrees(void)
  */
 double piv_get_position_degrees(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return piv_get_position() * PIV_RESOLVER_SCALING;
     } else {
         return 0;
@@ -576,7 +582,7 @@ double piv_get_position_degrees(void)
  */
 double rw_get_velocity_dps(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *motor_velocity[rw_index] * 0.1 * RW_ENCODER_SCALING;
     } else {
         return 0;
@@ -591,7 +597,7 @@ double rw_get_velocity_dps(void)
  */
 double el_get_velocity_dps(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *motor_velocity[el_index] * 0.1 * EL_MOTOR_ENCODER_SCALING;
     } else {
         return 0;
@@ -606,7 +612,7 @@ double el_get_velocity_dps(void)
  */
 double piv_get_velocity_dps(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *motor_velocity[piv_index] * 0.1 * PIV_RESOLVER_SCALING;
     } else {
         return 0;
@@ -621,7 +627,7 @@ double piv_get_velocity_dps(void)
  */
 int32_t rw_get_velocity(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *motor_velocity[rw_index];
     } else {
         return 0;
@@ -636,7 +642,7 @@ int32_t rw_get_velocity(void)
  */
 int32_t el_get_velocity(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *motor_velocity[el_index];
     } else {
         return 0;
@@ -651,7 +657,7 @@ int32_t el_get_velocity(void)
  */
 int32_t piv_get_velocity(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *motor_velocity[piv_index];
     } else {
         return 0;
@@ -666,7 +672,7 @@ int32_t piv_get_velocity(void)
  */
 int16_t rw_get_current(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *motor_current[rw_index];
     } else {
         return 0;
@@ -681,7 +687,7 @@ int16_t rw_get_current(void)
  */
 int16_t el_get_current(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *motor_current[el_index]*EL_MOTOR_CURRENT_SCALING;
     } else {
         return 0;
@@ -696,7 +702,7 @@ int16_t el_get_current(void)
  */
 int16_t piv_get_current(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *motor_current[piv_index];
     } else {
         return 0;
@@ -711,7 +717,7 @@ int16_t piv_get_current(void)
  */
 uint16_t rw_get_status_word(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *status_word[rw_index];
     } else {
         return 0;
@@ -726,7 +732,7 @@ uint16_t rw_get_status_word(void)
  */
 uint16_t el_get_status_word(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *status_word[el_index];
     } else {
         return 0;
@@ -741,7 +747,7 @@ uint16_t el_get_status_word(void)
  */
 uint16_t piv_get_status_word(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *status_word[piv_index];
     } else {
         return 0;
@@ -756,7 +762,7 @@ uint16_t piv_get_status_word(void)
  */
 uint32_t rw_get_status_register(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *status_register[rw_index];
     } else {
         return 0;
@@ -771,7 +777,7 @@ uint32_t rw_get_status_register(void)
  */
 uint32_t el_get_status_register(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *status_register[el_index];
     } else {
         return 0;
@@ -786,7 +792,7 @@ uint32_t el_get_status_register(void)
  */
 uint32_t piv_get_status_register(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *status_register[piv_index];
     } else {
         return 0;
@@ -801,7 +807,7 @@ uint32_t piv_get_status_register(void)
  */
 int16_t rw_get_amp_temp(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         return *amp_temp[rw_index];
     } else {
         return 0;
@@ -816,7 +822,7 @@ int16_t rw_get_amp_temp(void)
  */
 int16_t el_get_amp_temp(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         return *amp_temp[el_index];
     } else {
         return 0;
@@ -831,7 +837,7 @@ int16_t el_get_amp_temp(void)
  */
 int16_t piv_get_amp_temp(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         return *amp_temp[piv_index];
     } else {
         return 0;
@@ -846,7 +852,7 @@ int16_t piv_get_amp_temp(void)
  */
 void rw_set_current(int16_t m_cur)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         *target_current[rw_index] = m_cur;
     }
 }
@@ -859,7 +865,7 @@ void rw_set_current(int16_t m_cur)
  */
 void el_set_current(int16_t m_cur)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         *target_current[el_index] = m_cur*EL_MOTOR_CURRENT_SCALING;
     }
 }
@@ -872,7 +878,7 @@ void el_set_current(int16_t m_cur)
  */
 void piv_set_current(int16_t m_cur)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         *target_current[piv_index] = m_cur;
     }
 }
@@ -885,7 +891,7 @@ void piv_set_current(int16_t m_cur)
  */
 void rw_enable(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         *control_word[rw_index] = ECAT_CTL_ON | ECAT_CTL_ENABLE_VOLTAGE | ECAT_CTL_QUICK_STOP| ECAT_CTL_ENABLE;
     }
 }
@@ -898,7 +904,7 @@ void rw_enable(void)
  */
 void el_enable(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         *control_word[el_index] = ECAT_CTL_ON | ECAT_CTL_ENABLE_VOLTAGE | ECAT_CTL_QUICK_STOP| ECAT_CTL_ENABLE;
     }
 }
@@ -911,7 +917,7 @@ void el_enable(void)
  */
 void piv_enable(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         *control_word[piv_index] = ECAT_CTL_ON | ECAT_CTL_ENABLE_VOLTAGE | ECAT_CTL_QUICK_STOP| ECAT_CTL_ENABLE;
     }
 }
@@ -924,7 +930,7 @@ void piv_enable(void)
  */
 void rw_disable(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         *control_word[rw_index] &= (~ECAT_CTL_ENABLE);
     }
 }
@@ -937,7 +943,7 @@ void rw_disable(void)
  */
 void el_disable(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         *control_word[el_index] &= (~ECAT_CTL_ENABLE);
     }
 }
@@ -950,7 +956,7 @@ void el_disable(void)
  */
 void piv_disable(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         *control_word[piv_index] &= (~ECAT_CTL_ENABLE);
     }
 }
@@ -962,7 +968,7 @@ void piv_disable(void)
  */
 void rw_quick_stop(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         *control_word[rw_index] &= (~ECAT_CTL_QUICK_STOP);
     }
 }
@@ -974,7 +980,7 @@ void rw_quick_stop(void)
  */
 void el_quick_stop(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         *control_word[el_index] &= (~ECAT_CTL_QUICK_STOP);
     }
 }
@@ -986,7 +992,7 @@ void el_quick_stop(void)
  */
 void piv_quick_stop(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         *control_word[piv_index] &= (~ECAT_CTL_QUICK_STOP);
     }
 }
@@ -998,7 +1004,7 @@ void piv_quick_stop(void)
  */
 void rw_reset_fault(void)
 {
-    if (check_slave_comm_ready(rw_index)) {
+    if (check_peripheral_comm_ready(rw_index)) {
         *control_word[rw_index] |= ECAT_CTL_RESET_FAULT;
     }
 }
@@ -1010,7 +1016,7 @@ void rw_reset_fault(void)
  */
 void el_reset_fault(void)
 {
-    if (check_slave_comm_ready(el_index)) {
+    if (check_peripheral_comm_ready(el_index)) {
         *control_word[el_index] |= ECAT_CTL_RESET_FAULT;
     }
 }
@@ -1022,7 +1028,7 @@ void el_reset_fault(void)
  */
 void piv_reset_fault(void)
 {
-    if (check_slave_comm_ready(piv_index)) {
+    if (check_peripheral_comm_ready(piv_index)) {
         *control_word[piv_index] |= ECAT_CTL_RESET_FAULT;
     }
 }
@@ -1178,13 +1184,13 @@ static void piv_init_resolver(void)
 /**
  * @brief initializes the ethercat heartbeat to make sure we remain connected to a motor controller
  * 
- * @param slave_index index of the particular motor to monitor
+ * @param periph_index index of the particular motor to monitor
  */
-static void ec_init_heartbeat(int slave_index)
+static void ec_init_heartbeat(int periph_index)
 {
-    if (slave_index) {
-        ec_SDOwrite16(slave_index, ECAT_HEARTBEAT_TIME, HEARTBEAT_MS);
-        ec_SDOwrite8(slave_index, ECAT_LIFETIME_FACTOR, LIFETIME_FACTOR_EC);
+    if (periph_index) {
+        ec_SDOwrite16(periph_index, ECAT_HEARTBEAT_TIME, HEARTBEAT_MS);
+        ec_SDOwrite8(periph_index, ECAT_LIFETIME_FACTOR, LIFETIME_FACTOR_EC);
     }
 }
 
@@ -1199,10 +1205,10 @@ static int find_controllers(void)
     ec_mcp_state.n_found = ec_config(false, &io_map);
 //    blast_info("after ec_config io_map pointer %p pointer to pointer %p", io_map, &io_map);
     if (ec_mcp_state.n_found <= 0) {
-        berror(err, "No motor controller slaves found on the network!");
+        berror(err, "No motor controller peripherals found on the network!");
         return -1;
     }
-    blast_startup("ec_config returns %d slaves found", ec_mcp_state.n_found);
+    blast_startup("ec_config returns %d peripherals found", ec_mcp_state.n_found);
 
     if (ec_mcp_state.n_found < (N_MCs -1)) {
         ec_mcp_state.status = ECAT_MOTOR_FOUND_PARTIAL;
@@ -1210,22 +1216,22 @@ static int find_controllers(void)
         ec_mcp_state.status = ECAT_MOTOR_FOUND;
     }
 
-    /* wait for all slaves to reach SAFE_OP state */
+    /* wait for all peripherals to reach SAFE_OP state */
     if (ec_statecheck(0, EC_STATE_SAFE_OP, EC_TIMEOUTSTATE * (N_MCs - 1)) != EC_STATE_SAFE_OP) {
         ec_mcp_state.status = ECAT_MOTOR_RUNNING_PARTIAL;
-        blast_err("Not all slaves reached safe operational state.");
+        blast_err("Not all peripherals reached safe operational state.");
         ec_readstate();
-        for (int i = 1; i <= ec_slavecount; i++) {
-            if (ec_slave[i].state != EC_STATE_SAFE_OP) {
-                blast_err("Slave %d State=%2x StatusCode=%4x : %s", i, ec_slave[i].state,
-                        ec_slave[i].ALstatuscode, ec_ALstatuscode2string(ec_slave[i].ALstatuscode));
+        for (int i = 1; i <= ec_periphcount; i++) {
+            if (ec_periph[i].state != EC_STATE_SAFE_OP) {
+                blast_err("Peripheral %d State=%2x StatusCode=%4x : %s", i, ec_periph[i].state,
+                        ec_periph[i].ALstatuscode, ec_ALstatuscode2string(ec_periph[i].ALstatuscode));
             }
         }
     } else {
         ec_mcp_state.status = ECAT_MOTOR_RUNNING;
     }
-    ec_mcp_state.slave_count = ec_slavecount;
-    for (int i = 1; i <= ec_slavecount; i++) {
+    ec_mcp_state.periph_count = ec_periphcount;
+    for (int i = 1; i <= ec_periphcount; i++) {
         controller_state[i].index = i;
         /**
          * Configure the index values for later use.  These are mapped to the hard-set
@@ -1236,35 +1242,35 @@ static int find_controllers(void)
         ec_SDOread(i, 0x2384, 1, false, &size, &serial, EC_TIMEOUTRXM);
         if (serial == RW_SN) {
             blast_startup("Reaction Wheel Motor Controller %d: %s: SN: %4x",
-                          ec_slave[i].aliasadr, ec_slave[i].name, serial);
+                          ec_periph[i].aliasadr, ec_periph[i].name, serial);
             rw_index = i;
             blast_info("Setting rw_index to %d", rw_index);
-            blast_info("ec_slave[%d].outputs = %p", i, ec_slave[i].outputs);
+            blast_info("ec_periph[%d].outputs = %p", i, ec_periph[i].outputs);
            controller_state[i].is_mc = 1;
         } else if (serial == PIV_SN) {
             blast_startup("Pivot Motor Controller %d: %s: SN: %4x",
-                          ec_slave[i].aliasadr, ec_slave[i].name, serial);
+                          ec_periph[i].aliasadr, ec_periph[i].name, serial);
             piv_index = i;
             blast_info("Setting piv_index to %d", piv_index);
-            blast_info("ec_slave[%d].outputs = %p", i, ec_slave[i].outputs);
+            blast_info("ec_periph[%d].outputs = %p", i, ec_periph[i].outputs);
             controller_state[i].is_mc = 1;
         } else if (serial == EL_SN) {
             blast_startup("Elevation Motor Controller %d: %s: SN: %4x",
-                          ec_slave[i].aliasadr, ec_slave[i].name, serial);
+                          ec_periph[i].aliasadr, ec_periph[i].name, serial);
             el_index = i;
             controller_state[i].is_mc = 1;
             blast_info("Setting el_index to %d", el_index);
-            blast_info("ec_slave[%d].outputs = %p", i, ec_slave[i].outputs);
+            blast_info("ec_periph[%d].outputs = %p", i, ec_periph[i].outputs);
         } else {
-            blast_warn("Got unknown MC %s at position %d with alias %d",
-                       ec_slave[i].name, ec_slave[i].configadr, ec_slave[i].aliasadr);
+            blast_warn("Got unknown MC %s at position %d with serial %#4x and alias %d",
+                       ec_periph[i].name, ec_periph[i].configadr, serial, ec_periph[i].aliasadr);
             controller_state[i].ec_unknown = 1;
         }
     }
     while (ec_iserror()) {
         blast_err("%s", ec_elist2string());
     }
-    return ec_slavecount;
+    return ec_periphcount;
 }
 
 
@@ -1276,31 +1282,31 @@ static int find_controllers(void)
  * In general, we save these parameters to the FLASH of the controller before flight but this function
  * acts to ensure a correct mapping upon startup, should the flash be corrupted.
  *
- * @param m_slave Slave index number to configure.
+ * @param m_periph Motor controller index number to configure.
  * @return -1 on failure otherwise 0
  */
-static int motor_pdo_init(int m_slave)
+static int motor_pdo_init(int m_periph)
 {
     pdo_mapping_t map;
     int retval = 0;
 
-    if (ec_slave[m_slave].state != EC_STATE_SAFE_OP && ec_slave[m_slave].state != EC_STATE_PRE_OP) {
+    if (ec_periph[m_periph].state != EC_STATE_SAFE_OP && ec_periph[m_periph].state != EC_STATE_PRE_OP) {
         blast_err("Motor Controller %d (%s) is not in pre-operational state!  Cannot configure.",
-                  m_slave, ec_slave[m_slave].name);
+                  m_periph, ec_periph[m_periph].name);
         return -1;
     }
 
-    blast_startup("Configuring PDO Mappings for controller %d (%s)", m_slave, ec_slave[m_slave].name);
+    blast_startup("Configuring PDO Mappings for controller %d (%s)", m_periph, ec_periph[m_periph].name);
 
     /**
      * To program the PDO mapping, we first must clear the old state
      */
 
-    if (!ec_SDOwrite8(m_slave, ECAT_TXPDO_ASSIGNMENT, 0, 0)) {
+    if (!ec_SDOwrite8(m_periph, ECAT_TXPDO_ASSIGNMENT, 0, 0)) {
         blast_err("Failed mapping!");
     }
     for (int i = 0; i < 4; i++) {
-        if (!ec_SDOwrite8(m_slave, ECAT_TXPDO_MAPPING + i, 0, 0)) {
+        if (!ec_SDOwrite8(m_periph, ECAT_TXPDO_MAPPING + i, 0, 0)) {
             blast_err("Failed mapping!");
         }
     }
@@ -1312,19 +1318,19 @@ static int motor_pdo_init(int m_slave)
      * First map (0x1a00 register)
      */
     map_pdo(&map, ECAT_MOTOR_POSITION, 32);  // Motor Position
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING, 1, map.val)) {
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING, 1, map.val)) {
         blast_err("Failed mapping!");
     }
 
     map_pdo(&map, ECAT_VEL_ACTUAL, 32);     // Actual Motor Velocity
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING, 2, map.val)) {
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING, 2, map.val)) {
         blast_err("Failed mapping!");
     }
 
-    if (!ec_SDOwrite8(m_slave, ECAT_TXPDO_MAPPING, 0, 2)) {/// Set the 0x1a00 map to contain 2 elements
+    if (!ec_SDOwrite8(m_periph, ECAT_TXPDO_MAPPING, 0, 2)) {/// Set the 0x1a00 map to contain 2 elements
         blast_err("Failed mapping!");
     }
-    if (!ec_SDOwrite16(m_slave, ECAT_TXPDO_ASSIGNMENT, 1, ECAT_TXPDO_MAPPING)) {/// 0x1a00 maps to the first PDO
+    if (!ec_SDOwrite16(m_periph, ECAT_TXPDO_ASSIGNMENT, 1, ECAT_TXPDO_MAPPING)) {/// 0x1a00 maps to the first PDO
         blast_err("Failed mapping!");
     }
 
@@ -1332,24 +1338,24 @@ static int motor_pdo_init(int m_slave)
      * Second map (0x1a01 register)
 
     map_pdo(&map, ECAT_ACTUAL_POSITION, 32); // Actual Position (load for El, duplicates ECAT_MOTOR_POSITION for others)
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING+1, 1, map.val)) blast_err("Failed mapping!");
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING+1, 1, map.val)) blast_err("Failed mapping!");
 
      */
     map_pdo(&map, ECAT_CTL_WORD, 16); // Control Word
-    retval = ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING + 1, 2, map.val);
+    retval = ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING + 1, 2, map.val);
     if (!retval) {
         blast_err("Failed mapping!");
     }
 
     map_pdo(&map, ECAT_NET_STATUS, 16); // Network Status (including heartbeat monitor)
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING + 1, 3, map.val)) {
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING + 1, 3, map.val)) {
         blast_err("Failed mapping!");
     }
 
-    if (!ec_SDOwrite8(m_slave, ECAT_TXPDO_MAPPING + 1, 0, 3)) {/// Set the 0x1a01 map to contain 3 elements
+    if (!ec_SDOwrite8(m_periph, ECAT_TXPDO_MAPPING + 1, 0, 3)) {/// Set the 0x1a01 map to contain 3 elements
         blast_err("Failed mapping!");
     }
-    if (!ec_SDOwrite16(m_slave, ECAT_TXPDO_ASSIGNMENT, 2, ECAT_TXPDO_MAPPING + 1)) {/// 0x1a01 maps to the second PDO
+    if (!ec_SDOwrite16(m_periph, ECAT_TXPDO_ASSIGNMENT, 2, ECAT_TXPDO_MAPPING + 1)) {/// 0x1a01 maps to the second PDO
         blast_err("Failed mapping!");
     }
     while (ec_iserror()) {
@@ -1360,24 +1366,24 @@ static int motor_pdo_init(int m_slave)
      * Third map (0x1a02 register)
      */
     map_pdo(&map, ECAT_DRIVE_STATUS, 32); // Status Register
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING+2, 1, map.val)) {
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING+2, 1, map.val)) {
         blast_err("Failed mapping!");
     }
 
     map_pdo(&map, ECAT_CTL_STATUS, 16); // Status Word
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING + 2, 2, map.val)) {
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING + 2, 2, map.val)) {
         blast_err("Failed mapping!");
     }
 
     map_pdo(&map, ECAT_DRIVE_TEMP, 16); // Amplifier Temp (deg C)
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING + 2, 3, map.val)) {
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING + 2, 3, map.val)) {
         blast_err("Failed mapping!");
     }
 
-    if (!ec_SDOwrite8(m_slave, ECAT_TXPDO_MAPPING + 2, 0, 3)) {/// Set the 0x1a02 map to contain 3 elements
+    if (!ec_SDOwrite8(m_periph, ECAT_TXPDO_MAPPING + 2, 0, 3)) {/// Set the 0x1a02 map to contain 3 elements
         blast_err("Failed mapping!");
     }
-    if (!ec_SDOwrite16(m_slave, ECAT_TXPDO_ASSIGNMENT, 3, ECAT_TXPDO_MAPPING + 2)) {/// 0x1a02 maps to the third PDO
+    if (!ec_SDOwrite16(m_periph, ECAT_TXPDO_ASSIGNMENT, 3, ECAT_TXPDO_MAPPING + 2)) {/// 0x1a02 maps to the third PDO
         blast_err("Failed mapping!");
     }
     while (ec_iserror()) {
@@ -1388,28 +1394,28 @@ static int motor_pdo_init(int m_slave)
      * Fourth map (0x1a03 register)
      */
     map_pdo(&map, ECAT_LATCHED_DRIVE_FAULT, 32); // Latched Fault Register
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING + 3, 1, map.val)) {
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING + 3, 1, map.val)) {
         blast_err("Failed mapping!");
     }
 
     map_pdo(&map, ECAT_CURRENT_ACTUAL, 16); // Measured current output
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING + 3, 2, map.val)) {
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING + 3, 2, map.val)) {
         blast_err("Failed mapping!");
     }
 
 //    map_pdo(&map, ECAT_PHASE_ANGLE, 16); // Motor phase angle
     map_pdo(&map, ECAT_COMMUTATION_ANGLE, 16); // Commutation angle
-    if (!ec_SDOwrite32(m_slave, ECAT_TXPDO_MAPPING + 3, 3, map.val)) {
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING + 3, 3, map.val)) {
         blast_err("Failed mapping!");
     }
 
-    if (!ec_SDOwrite8(m_slave, ECAT_TXPDO_MAPPING + 3, 0, 3)) {/// Set the 0x1a03 map to contain 3 elements
+    if (!ec_SDOwrite8(m_periph, ECAT_TXPDO_MAPPING + 3, 0, 3)) {/// Set the 0x1a03 map to contain 3 elements
         blast_err("Failed mapping!");
     }
-    if (!ec_SDOwrite16(m_slave, ECAT_TXPDO_ASSIGNMENT, 4, ECAT_TXPDO_MAPPING + 3)) {/// 0x1a03 maps to the fourth PDO
+    if (!ec_SDOwrite16(m_periph, ECAT_TXPDO_ASSIGNMENT, 4, ECAT_TXPDO_MAPPING + 3)) {/// 0x1a03 maps to the fourth PDO
         blast_err("Failed mapping!");
     }
-    if (!ec_SDOwrite8(m_slave, ECAT_TXPDO_ASSIGNMENT, 0, 4)) {/// There are four maps in the TX PDOs
+    if (!ec_SDOwrite8(m_periph, ECAT_TXPDO_ASSIGNMENT, 0, 4)) {/// There are four maps in the TX PDOs
         blast_err("Failed mapping!");
     }
 
@@ -1417,15 +1423,15 @@ static int motor_pdo_init(int m_slave)
         blast_err("%s", ec_elist2string());
     }
 
-//    blast_info("ec_slave[%d].outputs = %p", m_slave, ec_slave[m_slave].outputs);
+//    blast_info("ec_periph[%d].outputs = %p", m_periph, ec_periph[m_periph].outputs);
 
     /**
      * To program the PDO mapping, we first must clear the old state
      */
     for (int i = 0; i < 4; i++) {
-        ec_SDOwrite8(m_slave, ECAT_RXPDO_MAPPING + i, 0, 0);
+        ec_SDOwrite8(m_periph, ECAT_RXPDO_MAPPING + i, 0, 0);
     }
-    ec_SDOwrite8(m_slave, ECAT_RXPDO_ASSIGNMENT, 0, 0);
+    ec_SDOwrite8(m_periph, ECAT_RXPDO_ASSIGNMENT, 0, 0);
     /**
      * Define the PDOs that we want to send from the flight computer to the Controllers
      */
@@ -1433,22 +1439,22 @@ static int motor_pdo_init(int m_slave)
      * First map (0x1600 register)
      */
     map_pdo(&map, ECAT_CTL_WORD, 16);   // Control Word
-    ec_SDOwrite32(m_slave, ECAT_RXPDO_MAPPING, 1, map.val);
+    ec_SDOwrite32(m_periph, ECAT_RXPDO_MAPPING, 1, map.val);
 
     map_pdo(&map, ECAT_CURRENT_LOOP_CMD, 16);    // Target Current
-    ec_SDOwrite32(m_slave, ECAT_RXPDO_MAPPING, 2, map.val);
+    ec_SDOwrite32(m_periph, ECAT_RXPDO_MAPPING, 2, map.val);
 
 // Uncomment this once the phasing angle readout has been debugged
 //    map_pdo(&map, ECAT_PHASING_MODE, 16);    // Phasing Mode
-//    ec_SDOwrite32(m_slave, ECAT_RXPDO_MAPPING, 3, map.val);
+//    ec_SDOwrite32(m_periph, ECAT_RXPDO_MAPPING, 3, map.val);
 
-    ec_SDOwrite8(m_slave, ECAT_RXPDO_MAPPING, 0, 2); /// Set the 0x1600 map to contain 2 elements
-    ec_SDOwrite16(m_slave, ECAT_RXPDO_ASSIGNMENT, 1, ECAT_RXPDO_MAPPING); /// Set the 0x1600 map to the first PDO
+    ec_SDOwrite8(m_periph, ECAT_RXPDO_MAPPING, 0, 2); /// Set the 0x1600 map to contain 2 elements
+    ec_SDOwrite16(m_periph, ECAT_RXPDO_ASSIGNMENT, 1, ECAT_RXPDO_MAPPING); /// Set the 0x1600 map to the first PDO
 
-    ec_SDOwrite8(m_slave, ECAT_RXPDO_ASSIGNMENT, 0, 1); /// There is on map in the RX PDOs
+    ec_SDOwrite8(m_periph, ECAT_RXPDO_ASSIGNMENT, 0, 1); /// There is on map in the RX PDOs
 
-    ec_SDOwrite32(m_slave, 0x2420, 0, 8);           // MISC settings for aborting trajectory, saving PDO map
-    ec_SDOwrite32(m_slave, 0x1010, 1, 0x65766173);  // Save all objects (the 0x65766173 is hex for 'save')
+    ec_SDOwrite32(m_periph, 0x2420, 0, 8);           // MISC settings for aborting trajectory, saving PDO map
+    ec_SDOwrite32(m_periph, 0x1010, 1, 0x65766173);  // Save all objects (the 0x65766173 is hex for 'save')
 
     while (ec_iserror()) {
         blast_err("%s", ec_elist2string());
@@ -1458,7 +1464,7 @@ static int motor_pdo_init(int m_slave)
 
 
 /**
- * @brief Generic mapping function for ethercat slave PDO variables.  This function works with
+ * @brief Generic mapping function for ethercat peripheral PDO variables.  This function works with
  * motor_pdo_init to set up the PDO input/output memory mappings for the motor controllers
  * @param m_index position on the ethercat chain
  */
@@ -1479,7 +1485,7 @@ static void map_index_vars(int m_index)
         pdo_channel_map_t *ch = (pdo_channel_map_t*)el->data; \
         if (ch->index == object_index(_obj) && \
                 ch->subindex == object_subindex(_obj)) { \
-            _map[m_index] = (typeof(_map[0])) (ec_slave[m_index].inputs + ch->offset); \
+            _map[m_index] = (typeof(_map[0])) (ec_periph[m_index].inputs + ch->offset); \
             found = true; \
         } \
     } \
@@ -1510,13 +1516,14 @@ static void map_index_vars(int m_index)
     // TODO(seth): Add dynamic mapping to outputs
     /// Outputs
     if (controller_state[m_index].is_mc) {
-        control_word[m_index] = (uint16_t*) (ec_slave[m_index].outputs);
+        control_word[m_index] = (uint16_t*) (ec_periph[m_index].outputs);
         target_current[m_index] = (int16_t*) (control_word[m_index] + 1);
-        if (!(ec_slave[m_index].outputs)) {
-            blast_err("Error: IOmap was not configured correctly!  Setting slave_error = 1 for slave %d...", m_index);
-            controller_state[m_index].slave_error = 1;
+        if (!(ec_periph[m_index].outputs)) {
+            blast_err("Error: IOmap was not configured correctly!"
+                "Setting periph_error = 1 for peripheral %d...", m_index);
+            controller_state[m_index].periph_error = 1;
         } else {
-            controller_state[m_index].slave_error = 0;
+            controller_state[m_index].periph_error = 0;
         }
     }
     while (ec_iserror()) {
@@ -1554,7 +1561,7 @@ static void map_motor_vars(void)
 
 /**
  * @brief There must be only a single distributed clock master on the entire bus.  This should be one of the
- * controllers and so we choose the first slave that has dc enabled as the SYNC master.  Everyone
+ * controllers and so we choose the first peripheral that has dc enabled as the SYNC master.  Everyone
  * else on the bus gets the same DC_CYCLE (in nanoseconds) but have their sync disabled.
  */
 static void motor_configure_timing(void)
@@ -1564,15 +1571,15 @@ static void motor_configure_timing(void)
     while (ec_iserror()) {
         blast_err("Error after ec_iserror(), %s", ec_elist2string());
     }
-    for (int i = 1; i <= ec_slavecount; i++) {
-        if (!found_dc_master && ec_slave[i].hasdc) {
-            ec_dcsync0(i, true, ECAT_DC_CYCLE_NS, ec_slave[i].pdelay);
+    for (int i = 1; i <= ec_periphcount; i++) {
+        if (!found_dc_master && ec_periph[i].hasdc) {
+            ec_dcsync0(i, true, ECAT_DC_CYCLE_NS, ec_periph[i].pdelay);
             found_dc_master = 1;
         } else {
-            ec_dcsync0(i, false, ECAT_DC_CYCLE_NS, ec_slave[i].pdelay);
+            ec_dcsync0(i, false, ECAT_DC_CYCLE_NS, ec_periph[i].pdelay);
         }
         while (ec_iserror()) {
-            blast_err("Slave %i, %s", i, ec_elist2string());
+            blast_err("Peripheral %i, %s", i, ec_elist2string());
         }
         /**
          * Set the SYNC Manager mode to free-running so that we get data from the drive as soon as
@@ -1580,9 +1587,9 @@ static void motor_configure_timing(void)
          */
         ec_SDOwrite16(i, 0x1C32, 1, 0);
         while (ec_iserror()) {
-            blast_err("Slave %i, %s", i, ec_elist2string());
+            blast_err("Peripheral %i, %s", i, ec_elist2string());
         }
-        if (ec_slave[i].hasdc && found_dc_master) {
+        if (ec_periph[i].hasdc && found_dc_master) {
             controller_state[i].has_dc = 1;
         } else {
             controller_state[i].has_dc = 0;
@@ -1598,20 +1605,20 @@ static void motor_configure_timing(void)
  */
 static int motor_set_operational(void)
 {
-    /* send one processdata cycle to init SM in slaves */
+    /* send one processdata cycle to init SM in peripherals */
     ec_send_processdata();
     ec_receive_processdata(EC_TIMEOUTRET);
 
-    ec_slave[0].state = EC_STATE_OPERATIONAL;
+    ec_periph[0].state = EC_STATE_OPERATIONAL;
 
-    /* send one valid process data to make outputs in slaves happy*/
+    /* send one valid process data to make outputs in peripherals happy*/
     ec_send_processdata();
     ec_receive_processdata(EC_TIMEOUTRET);
 
-    /* request OP state for all slaves */
+    /* request OP state for all peripherals */
     ec_writestate(0);
 
-    /* wait for all slaves to reach OP state */
+    /* wait for all peripherals to reach OP state */
     for (int i = 0; i < 40; i++) {
         ec_send_processdata();
         ec_receive_processdata(EC_TIMEOUTRET);
@@ -1623,7 +1630,7 @@ static int motor_set_operational(void)
     /**
      * If we've reached fully operational state, return
      */
-    if (ec_slave[0].state == EC_STATE_OPERATIONAL) {
+    if (ec_periph[0].state == EC_STATE_OPERATIONAL) {
         blast_info("We have reached a fully operational state.");
         ec_mcp_state.status = ECAT_MOTOR_RUNNING;
         return 0;
@@ -1632,10 +1639,10 @@ static int motor_set_operational(void)
     /**
      * Something has prevented a motor controller from entering operational mode (EtherCAT Ops)
      */
-    for (int i = 1; i <= ec_slavecount; i++) {
-        if (ec_slave[i].state != EC_STATE_OPERATIONAL) {
-            blast_err("Slave %d State=%2x StatusCode=%4x : %s", i, ec_slave[i].state,
-                    ec_slave[i].ALstatuscode, ec_ALstatuscode2string(ec_slave[i].ALstatuscode));
+    for (int i = 1; i <= ec_periphcount; i++) {
+        if (ec_periph[i].state != EC_STATE_OPERATIONAL) {
+            blast_err("Peripheral %d State=%2x StatusCode=%4x : %s", i, ec_periph[i].state,
+                    ec_periph[i].ALstatuscode, ec_ALstatuscode2string(ec_periph[i].ALstatuscode));
         }
     }
     while (ec_iserror()) {
@@ -1663,7 +1670,7 @@ static uint8_t check_ec_ready(int index)
     if (!controller_state[index].is_mc) {
         return(0);
     }
-    if (check_slave_comm_ready(index)) {
+    if (check_peripheral_comm_ready(index)) {
         if (!((*control_word_read[index]) == (*control_word[index])) ||
                (*status_register[el_index] & ECAT_STATUS_PHASE_UNINIT) ||
                !(*status_word[index] & ECAT_CTL_STATUS_READY) ) {
@@ -1805,9 +1812,9 @@ static void read_motor_data()
 /**
  * @brief Takes the PDOs and susses out the mapping for later use
  * 
- * @param m_slave which controller index to talk to
+ * @param m_periph which controller index to talk to
  */
-void mc_readPDOassign(int m_slave) {
+void mc_readPDOassign(int m_periph) {
     uint16 idxloop, nidx, subidxloop, rdat, idx, subidx;
     uint8 subcnt;
 //    GSList *m_pdo_list;
@@ -1818,12 +1825,12 @@ void mc_readPDOassign(int m_slave) {
     len = sizeof(rdat);
     rdat = 0;
 
-//    m_pdo_list = pdo_list[m_slave];
-//    blast_info("Starting mc_readPDOassign for slave %i", m_slave);
+//    m_pdo_list = pdo_list[m_periph];
+//    blast_info("Starting mc_readPDOassign for peripheral %i", m_periph);
     /* read PDO assign subindex 0 ( = number of PDO's) */
-    wkc = ec_SDOread(m_slave, ECAT_TXPDO_ASSIGNMENT, 0x00, FALSE, &len, &rdat, EC_TIMEOUTRXM);
+    wkc = ec_SDOread(m_periph, ECAT_TXPDO_ASSIGNMENT, 0x00, FALSE, &len, &rdat, EC_TIMEOUTRXM);
     rdat = etohs(rdat);
-    /* positive result from slave ? */
+    /* positive result from peripheral ? */
     blast_info("Result from ec_SDOread at index %04x, wkc = %i, len = %i, rdat = %04x",
                ECAT_TXPDO_ASSIGNMENT, wkc, len, rdat);
     if ((wkc <= 0) || (rdat <= 0))  {
@@ -1838,7 +1845,7 @@ void mc_readPDOassign(int m_slave) {
         len = sizeof(rdat);
         rdat = 0;
         /* read PDO assign */
-        wkc = ec_SDOread(m_slave, ECAT_TXPDO_ASSIGNMENT, (uint8) idxloop, FALSE, &len, &rdat, EC_TIMEOUTRXM);
+        wkc = ec_SDOread(m_periph, ECAT_TXPDO_ASSIGNMENT, (uint8) idxloop, FALSE, &len, &rdat, EC_TIMEOUTRXM);
         /* result is index of PDO */
         idx = etohl(rdat);
         if (idx <= 0) {
@@ -1849,7 +1856,7 @@ void mc_readPDOassign(int m_slave) {
         len = sizeof(subcnt);
         subcnt = 0;
         /* read number of subindexes of PDO */
-        wkc = ec_SDOread(m_slave, idx, 0x00, FALSE, &len, &subcnt, EC_TIMEOUTRXM);
+        wkc = ec_SDOread(m_periph, idx, 0x00, FALSE, &len, &subcnt, EC_TIMEOUTRXM);
         subidx = subcnt;
 //        blast_info("Number of subindexes: %i", subidx);
         /* for each subindex */
@@ -1859,15 +1866,15 @@ void mc_readPDOassign(int m_slave) {
             pdo_mapping_t pdo_map = { 0 };
             len = sizeof(pdo_map);
             /* read SDO that is mapped in PDO */
-            wkc = ec_SDOread(m_slave, idx, (uint8) subidxloop, FALSE, &len, &pdo_map, EC_TIMEOUTRXM);
+            wkc = ec_SDOread(m_periph, idx, (uint8) subidxloop, FALSE, &len, &pdo_map, EC_TIMEOUTRXM);
             channel = malloc(sizeof(pdo_channel_map_t));
             channel->index = pdo_map.index;
             channel->subindex = pdo_map.subindex;
             channel->offset = offset;
-            pdo_list[m_slave] = g_slist_prepend(pdo_list[m_slave], channel);
+            pdo_list[m_periph] = g_slist_prepend(pdo_list[m_periph], channel);
 //            blast_info("Read SDO subidxloop = %i, wkc = %i, idx = %i, len = %i", subidxloop, wkc, idx, len);
 //            blast_info("Appending channel to m_pdo_list = %p: index = %2x, subindex = %i, offset = %i",
-//                       pdo_list[m_slave], channel->index, channel->subindex, channel->offset);
+//                       pdo_list[m_periph], channel->index, channel->subindex, channel->offset);
 
             /// Offset is the number of bytes into the memory map this element is.  First element is 0 bytes in.
             offset += (pdo_map.size / 8);
@@ -1967,7 +1974,7 @@ int configure_ec_motors()
         CommandData.ec_devices.have_commutated_rw = 0;
         CommandData.ec_devices.rw_commutate_next_ec_reset = 0;
     }
-    for (int i = 1; i <= ec_slavecount; i++) {
+    for (int i = 1; i <= ec_periphcount; i++) {
         if (controller_state[i].is_mc) {
             motor_pdo_init(i);
             mc_readPDOassign(i);
@@ -1980,8 +1987,8 @@ int configure_ec_motors()
     /**
      * Set the initial values of both commands to "safe" default values
      */
-    for (int i = 1; i <= ec_slavecount; i++) {
-        if ((controller_state[i].is_mc) && !(controller_state[i].slave_error)) {
+    for (int i = 1; i <= ec_periphcount; i++) {
+        if ((controller_state[i].is_mc) && !(controller_state[i].periph_error)) {
             *target_current[i] = 0;
             *control_word[i] = ECAT_CTL_ON | ECAT_CTL_ENABLE_VOLTAGE | ECAT_CTL_QUICK_STOP| ECAT_CTL_ENABLE;
         }
@@ -2011,8 +2018,8 @@ int configure_ec_motors()
     motor_set_operational();
 
     blast_info("Writing the drive state to start current mode.");
-    for (int i = 1; i <= ec_slavecount; i++) {
-        if ((controller_state[i].slave_error == 0) && (controller_state[i].has_dc == 1)) {
+    for (int i = 1; i <= ec_periphcount; i++) {
+        if ((controller_state[i].periph_error == 0) && (controller_state[i].has_dc == 1)) {
             controller_state[i].comms_ok = 1;
         } else {
             controller_state[i].comms_ok = 0;
@@ -2044,7 +2051,7 @@ int reset_ec_motors()
         controller_state[i].is_mc = 0;
         controller_state[i].has_dc = 0;
         controller_state[i].comms_ok = 0;
-        controller_state[i].slave_error = 0;
+        controller_state[i].periph_error = 0;
     }
     configure_ec_motors();
     return(1);
@@ -2220,7 +2227,7 @@ uint8_t make_ec_status_field(int m_index)
     if ((m_index < 1) || (m_index >= N_MCs)) return m_stats;
     m_stats |= (m_index & 0x07);
     m_stats |= ((controller_state[m_index].comms_ok & 0x01) << 3);
-    m_stats |= ((controller_state[m_index].slave_error & 0x01) << 4);
+    m_stats |= ((controller_state[m_index].periph_error & 0x01) << 4);
     m_stats |= ((controller_state[m_index].has_dc & 0x01) << 5);
     m_stats |= ((controller_state[m_index].is_mc & 0x01) << 6);
     return m_stats;
@@ -2235,7 +2242,7 @@ void store_1hz_ethercat(void)
 {
     static int firsttime = 1;
     static channel_t *NFoundECAddr;
-    static channel_t *SlaveCountECAddr;
+    static channel_t *PeripheralCountECAddr;
     static channel_t *StatusECAddr;
     static channel_t *StatusECRWAddr;
     static channel_t *StatusECElAddr;
@@ -2243,7 +2250,7 @@ void store_1hz_ethercat(void)
 
     if (firsttime) {
         NFoundECAddr = channels_find_by_name("n_found_ec");
-        SlaveCountECAddr = channels_find_by_name("slave_count_ec");
+        PeripheralCountECAddr = channels_find_by_name("periph_count_ec");
         StatusECAddr = channels_find_by_name("status_ec");
         StatusECRWAddr = channels_find_by_name("status_ec_rw");
         StatusECElAddr = channels_find_by_name("status_ec_el");
@@ -2251,7 +2258,7 @@ void store_1hz_ethercat(void)
         firsttime = 0;
     }
     SET_UINT8(NFoundECAddr, ec_mcp_state.n_found);
-    SET_UINT8(SlaveCountECAddr, ec_mcp_state.slave_count);
+    SET_UINT8(PeripheralCountECAddr, ec_mcp_state.periph_count);
     SET_UINT8(StatusECAddr, ec_mcp_state.status);
     if (rw_index) SET_UINT8(StatusECRWAddr, make_ec_status_field(rw_index));
     if (el_index) SET_UINT8(StatusECElAddr, make_ec_status_field(el_index));

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -73,7 +73,7 @@ ec_slavet* ec_periph = ec_slave;
 // device node Serial Numbers
 #define RW_SN  0x35f4cc0d // 0x01bbbb65
 #define PIV_SN 0x02924687
-#define EL_SN 0x01238408
+#define EL_SN 0x35f4cc11
 // addresses on the EC network
 #define RW_ADDR 0x3
 #define EL_ADDR 0x2
@@ -161,9 +161,9 @@ static uint16_t *control_word[N_MCs] = { (uint16_t*) &dummy_write_var, (uint16_t
 static int16_t *target_current[N_MCs] = { (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var,
                                           (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var ,
                                           (int16_t*) &dummy_write_var };
-static int16_t *latched_register_writable[N_MCs] = { (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var,
-                                                     (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var ,
-                                                     (int16_t*) &dummy_write_var };
+// static int16_t *latched_register_writable[N_MCs] = { (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var,
+//                                                      (int16_t*) &dummy_write_var, (int16_t*) &dummy_write_var ,
+//                                                      (int16_t*) &dummy_write_var };
 
 
 
@@ -1463,10 +1463,10 @@ static int motor_pdo_init(int m_periph)
     if (!ec_SDOwrite32(m_periph, ECAT_RXPDO_MAPPING, 2, map.val)) {
         blast_err("Failed mapping!");
     }
-    map_pdo(&map, ECAT_LATCHED_DRIVE_FAULT, 32);
-    if (!ec_SDOwrite32(m_periph, ECAT_RXPDO_MAPPING, 3, map.val)) {
-        blast_err("Failed mapping!");
-    }
+    // map_pdo(&map, ECAT_LATCHED_DRIVE_FAULT, 32);
+    // if (!ec_SDOwrite32(m_periph, ECAT_RXPDO_MAPPING, 3, map.val)) {
+    //     blast_err("Failed mapping!");
+    // }
     // Uncomment this once the phasing angle readout has been debugged
     // map_pdo(&map, ECAT_PHASING_MODE, 16);    // Phasing Mode
     // if (!ec_SDOwrite32(m_periph, ECAT_RXPDO_MAPPING, 3, map.val)) {
@@ -1562,7 +1562,7 @@ static void map_index_vars(int m_index)
     if (controller_state[m_index].is_mc) {
         control_word[m_index] = (uint16_t*) (ec_periph[m_index].outputs);
         target_current[m_index] = (int16_t*) (control_word[m_index] + 1);
-        latched_register_writable[m_index] = (int16_t*) (control_word[m_index] + 2);
+        // latched_register_writable[m_index] = (int16_t*) (control_word[m_index] + 2);
         if (!(ec_periph[m_index].outputs)) {
             blast_err("Error: IOmap was not configured correctly!"
                 "Setting periph_error = 1 for peripheral %d...", m_index);
@@ -2035,7 +2035,7 @@ int configure_ec_motors()
     for (int i = 1; i <= ec_periphcount; i++) {
         if ((controller_state[i].is_mc) && !(controller_state[i].periph_error)) {
             *target_current[i] = 0;
-            *latched_register_writable[i] = 0xFFFFFFFF; // ECAT_FAULT_CMD_LOST;
+            // *latched_register_writable[i] = 0xFFFFFFFF; // ECAT_FAULT_CMD_LOST;
             *control_word[i] = ECAT_CTL_ON | ECAT_CTL_ENABLE_VOLTAGE | ECAT_CTL_QUICK_STOP| ECAT_CTL_ENABLE;
         }
     }

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -89,7 +89,7 @@ ec_slavet* ec_periph = ec_slave;
 #define N_MCs 4
 
 // device node Serial Numbers
-#define RW_SN  0x35f4cc0d // 0x01bbbb65
+#define RW_SN  0x35f4cc0d
 #define PIV_SN 0x02924687
 #define EL_SN 0x35f4cc11
 // addresses on the EC network
@@ -1336,11 +1336,11 @@ static void motor_configure_timing(void)
         // for a clock source, but run in free-run mode for now.
         // blast_info("Looking for distributed clock on peripheral %d", i);
         if (!found_dc_source && ec_periph[i].hasdc) {
-            ec_dcsync0(i, true, ECAT_DC_CYCLE_NS, ec_periph[i].pdelay);
+            // ec_dcsync0(i, true, ECAT_DC_CYCLE_NS, ec_periph[i].pdelay);
             found_dc_source = 1;
             // blast_info("Distributed clock source is peripheral %d", i);
         } else {
-            ec_dcsync0(i, false, ECAT_DC_CYCLE_NS, ec_periph[i].pdelay);
+            // ec_dcsync0(i, false, ECAT_DC_CYCLE_NS, ec_periph[i].pdelay);
         }
         // blast_info("Peripheral %d propagation delay is %d", i, ec_periph[i].pdelay);
         while (ec_iserror()) {


### PR DESCRIPTION
## Brief

Prepare EtherCAT motors code for TIM integration. Change parameters to match the new Copley BEL motor controllers, and make the startup process more robust.

## Detail

The guiding light for these changes is the SOEM [example code red_test.c](https://github.com/OpenEtherCATsociety/SOEM/blob/master/test/linux/red_test/red_test.c). It shows the proper configuration, sequence, and multithreaded implementation and is blessed by the SOEM developer.

In order of importance:
- Update drive serial numbers and current limits
- Stop trying to straddle two types of setup - [Distributed Clock and Free-Run](https://infosys.beckhoff.com/english.php?content=../content/1033/ethercatsystem/2469122443.html&id=)
  - This seems to fix an issue where ~25% of the time, a drive would come up fresh/after a reset with an EtherCAT state machine error related to synchronization
  - The mode for now is free-run: peripheral devices run on their own clocks, updating input/output data asynchronously with respect to the flight computer. This is less precise wrt coordinated motion, with timing probably floating between axes by something like 125 us (half the Copley drive [internal update rate](https://copleycontrols.com/wp-content/uploads/2018/02/EtherCAT-Synchronization-Application-Notes.pdf)), but should not matter for our application.
- Move process data send/recv calls to their own real-time thread
  - Allows us to turn on/off process data sending at the proper point during motor setup, critical for proper synchronization
  - Allows greater stability
- Implement a non-RT thread to look for and recover drives that have left operational state at any time after we begin running
- Logging enhancements