### PR TITLE
Fix reaction wheel angle and velocity readout

### DIFF
--- a/blast_config/include/calibrate.h
+++ b/blast_config/include/calibrate.h
@@ -30,7 +30,7 @@ extern "C" {
 /**
  * Scaling factors for each motor.  These are hard-wired based on the encoder/resolver
  */
-#define RW_ENCODER_COUNTS (1 << 21)
+#define RW_ENCODER_COUNTS (1 << 13)
 // Scaling factors for each motor.  These are hard-wired based on the encoder/resolver
 #define RW_COUNTS_PER_REV (1 << 13)
 // Scaling factors for each motor.  These are hard-wired based on the encoder/resolver

--- a/mcp/motors/ec_motors.c
+++ b/mcp/motors/ec_motors.c
@@ -1528,10 +1528,10 @@ static int motor_pdo_init(int m_periph)
     // Actual Position (for el, the position reported by an encoder not
     // directly connected to the motor shaft (the "load" encoder). Otherwise,
     // contains same data as ECAT_MOTOR_POSITION.
-    // map_pdo(&map, ECAT_ACTUAL_POSITION, 32);
-    // if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING+1, 1, map.val)) {
-    //    blast_err("Failed mapping!");
-    // }
+    map_pdo(&map, ECAT_ACTUAL_POSITION, 32);
+    if (!ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING+1, 1, map.val)) {
+       blast_err("Failed mapping!");
+    }
     map_pdo(&map, ECAT_CTL_WORD, 16);
     retval = ec_SDOwrite32(m_periph, ECAT_TXPDO_MAPPING + 1, 2, map.val);
     if (!retval) {


### PR DESCRIPTION
This fix updates the reaction wheel encoder resolution in software to match the encoder on the reaction wheel motor. This fixes the units for the scaled values in the telemetry display, correctly displaying them as degrees angle and degrees per second velocity. It also re-enables the reporting of the reaction wheel encoder position.

This fix was tested by spinning the reaction wheel by hand approximately 360 degrees and reading the change in angle in the `kst` telemetry window.