### PR TITLE
`owl` updates

### DIFF
--- a/mcp/sensors/acs.c
+++ b/mcp/sensors/acs.c
@@ -1254,7 +1254,6 @@ void store_5hz_acs(void)
     static channel_t *MagOKAddr[NUM_MAGS];
     static channel_t *EncMotorOK;
     static channel_t *DGPSOK;
-    static channel_t *ElClinOKAddr[NUM_INCS];
 
     /* trim fields */
     static channel_t *trimClinAddr[NUM_INCS];
@@ -1438,8 +1437,6 @@ void store_5hz_acs(void)
         MagOKAddr[0] = channels_find_by_name("ok_mag1");
         MagOKAddr[1] = channels_find_by_name("ok_mag2");
         EncMotorOK = channels_find_by_name("ok_motor_enc");
-        ElClinOKAddr[0] = channels_find_by_name("ok_elclin1");
-        ElClinOKAddr[1] = channels_find_by_name("ok_elclin2");
         DGPSOK = channels_find_by_name("ok_dgps");
 
         lstSchedAddr = channels_find_by_name("lst_sched");
@@ -1685,10 +1682,8 @@ void store_5hz_acs(void)
 
     SET_UINT16(vetoSensorAddr, sensor_veto);
     SET_UINT8(MagOKAddr[0], PointingData[i_point].mag_ok[0]);
-    SET_UINT8(MagOKAddr[1], PointingData[i_point].mag_ok[0]);
+    SET_UINT8(MagOKAddr[1], PointingData[i_point].mag_ok[1]);
     SET_UINT8(EncMotorOK, PointingData[i_point].enc_motor_ok);
-    SET_UINT8(ElClinOKAddr[0], PointingData[i_point].clin_ok[0]);
-    SET_UINT8(ElClinOKAddr[1], PointingData[i_point].clin_ok[1]);
     SET_UINT8(DGPSOK, PointingData[i_point].dgps_ok);
     SET_UINT16(weightAzAddr, PointingData[i_point].weight_az);
     SET_UINT16(weightElAddr, PointingData[i_point].weight_el);

--- a/mcp/sensors/inclinometer.c
+++ b/mcp/sensors/inclinometer.c
@@ -137,10 +137,12 @@ static void inc_set_framedata(float m_incx, float m_incy, float m_incTemp)
 void store_1hz_inc(void)
 {
     static int firsttime = 1;
+    uint8_t inc_ok = 0;
     static channel_t *StatusIncAddr;
     static channel_t *ErrCountIncAddr;
     static channel_t *TimeoutCountIncAddr;
     static channel_t *ResetCountIncAddr;
+    static channel_t *ClinOKaddr;
 
     if (firsttime) {
         if (SouthIAm) {
@@ -148,11 +150,13 @@ void store_1hz_inc(void)
             ErrCountIncAddr = channels_find_by_name("err_count_inc2_s");
             TimeoutCountIncAddr = channels_find_by_name("timeout_count_inc2_s");
             ResetCountIncAddr = channels_find_by_name("reset_count_inc2_s");
+            ClinOKaddr = channels_find_by_name("ok_elclin2");
         } else {
             StatusIncAddr = channels_find_by_name("status_inc1_n");
             ErrCountIncAddr = channels_find_by_name("err_count_inc1_n");
             TimeoutCountIncAddr = channels_find_by_name("timeout_count_inc1_n");
             ResetCountIncAddr = channels_find_by_name("reset_count_inc1_n");
+            ClinOKaddr = channels_find_by_name("ok_elclin1");
         }
         firsttime = 0;
     }
@@ -160,6 +164,12 @@ void store_1hz_inc(void)
     SET_UINT16(ErrCountIncAddr, inc_status.err_count);
     SET_UINT16(TimeoutCountIncAddr, inc_status.timeout_count);
     SET_UINT16(ResetCountIncAddr, inc_status.reset_count);
+    if (inc_status.state == INC_READING) {
+        inc_ok = 1;
+    } else {
+        inc_ok = 0;
+    }
+    SET_UINT8(ClinOKaddr, inc_ok);
 }
 
 

--- a/owl/owl-files/tim/motor_controller_status.owl
+++ b/owl/owl-files/tim/motor_controller_status.owl
@@ -11,7 +11,7 @@
             "_boxTitle": "Flight Computers",
             "_style": "(P695404123)",
             "cellHeight": 18,
-            "cellWidth": 16,
+            "cellWidth": 17,
             "cellX": 3,
             "cellY": 0,
             "dataItems": [
@@ -168,7 +168,7 @@
                 }
             ],
             "geometryHeight": 270,
-            "geometryWidth": 240,
+            "geometryWidth": 255,
             "geometryX": 45,
             "geometryY": 0
         },
@@ -184,34 +184,24 @@
             "cellY": 18,
             "dataItems": [
                 {
-                    "PObject": {
-                        "_id": "691366938"
-                    },
-                    "_caption": "Nodes Discovered ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "N_FOUND_EC",
-                    "type": "PNDI"
-                },
-                {
                     "PMDI": {
                         "PObject": {
-                            "_id": "423608236"
+                            "_id": "621882819"
                         },
                         "_map": {
-                            "0": " READY[style=TIM_GOOD (P1165535148)]",
-                            "1": " NOT READY[style=TIM_BAD (P1196047623)]"
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_WARN (P527972465)]",
+                            "2": "2[style=TIM_WARN (P527972465)]",
+                            "3": "3[style=TIM_GOOD (P1165535148)]"
                         }
                     },
                     "PObject": {
-                        "_id": "1770545002"
+                        "_id": "88366191"
                     },
-                    "_caption": "NETWORK_PROBLEM_RW",
+                    "_caption": "Nodes Discovered",
                     "_captionStyle": "noStyle",
                     "_defaultStyle": "noStyle",
-                    "_source": "NETWORK_PROBLEM_RW",
+                    "_source": "N_FOUND_EC",
                     "type": "PMDI"
                 },
                 {
@@ -246,10 +236,29 @@
                     "PObject": {
                         "_id": "1095149491"
                     },
-                    "_caption": "NETWORK_PROBLEM_PIV",
+                    "_caption": "NETWORK_PROBLEM_PIV ",
                     "_captionStyle": "noStyle",
                     "_defaultStyle": "noStyle",
                     "_source": "NETWORK_PROBLEM_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "423608236"
+                        },
+                        "_map": {
+                            "0": "READY[style=TIM_GOOD (P1165535148)]",
+                            "1": "NOT READY[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1770545002"
+                    },
+                    "_caption": "NETWORK_PROBLEM_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NETWORK_PROBLEM_RW",
                     "type": "PMDI"
                 }
             ],
@@ -266,7 +275,7 @@
             "_style": "(P512511192)",
             "cellHeight": 18,
             "cellWidth": 16,
-            "cellX": 19,
+            "cellX": 20,
             "cellY": 0,
             "dataItems": [
                 {
@@ -576,7 +585,7 @@
             ],
             "geometryHeight": 270,
             "geometryWidth": 240,
-            "geometryX": 285,
+            "geometryX": 300,
             "geometryY": 0
         },
         {
@@ -587,7 +596,7 @@
             "_style": "(P1771970462)",
             "cellHeight": 18,
             "cellWidth": 17,
-            "cellX": 35,
+            "cellX": 36,
             "cellY": 0,
             "dataItems": [
                 {
@@ -897,7 +906,7 @@
             ],
             "geometryHeight": 270,
             "geometryWidth": 255,
-            "geometryX": 525,
+            "geometryX": 540,
             "geometryY": 0
         },
         {
@@ -908,7 +917,7 @@
             "_style": "(P63343233)",
             "cellHeight": 18,
             "cellWidth": 17,
-            "cellX": 52,
+            "cellX": 53,
             "cellY": 0,
             "dataItems": [
                 {
@@ -1218,18 +1227,18 @@
             ],
             "geometryHeight": 270,
             "geometryWidth": 255,
-            "geometryX": 780,
+            "geometryX": 795,
             "geometryY": 0
         },
         {
             "PObject": {
                 "_id": "1575341178"
             },
-            "_boxTitle": "EL ECAT CTL Bitword (0x1002)",
+            "_boxTitle": "EL Mfgr. Status Register (0x1002)",
             "_style": "(P512511192)",
-            "cellHeight": 30,
+            "cellHeight": 31,
             "cellWidth": 16,
-            "cellX": 19,
+            "cellX": 20,
             "cellY": 18,
             "dataItems": [
                 {
@@ -1784,20 +1793,20 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 450,
+            "geometryHeight": 465,
             "geometryWidth": 240,
-            "geometryX": 285,
+            "geometryX": 300,
             "geometryY": 270
         },
         {
             "PObject": {
                 "_id": "898062968"
             },
-            "_boxTitle": "PIV ECAT CTL Bitword (0x1002)",
+            "_boxTitle": "PIV Mfgr. Status Register (0x1002)",
             "_style": "(P1771970462)",
-            "cellHeight": 30,
+            "cellHeight": 31,
             "cellWidth": 17,
-            "cellX": 35,
+            "cellX": 36,
             "cellY": 18,
             "dataItems": [
                 {
@@ -2352,20 +2361,20 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 450,
+            "geometryHeight": 465,
             "geometryWidth": 255,
-            "geometryX": 525,
+            "geometryX": 540,
             "geometryY": 270
         },
         {
             "PObject": {
                 "_id": "936106058"
             },
-            "_boxTitle": "RW ECAT CTL Bitword (0x1002)",
+            "_boxTitle": "RW Mfgr. Status Register (0x1002)",
             "_style": "(P63343233)",
-            "cellHeight": 30,
+            "cellHeight": 31,
             "cellWidth": 17,
-            "cellX": 52,
+            "cellX": 53,
             "cellY": 18,
             "dataItems": [
                 {
@@ -2920,20 +2929,20 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 450,
+            "geometryHeight": 465,
             "geometryWidth": 255,
-            "geometryX": 780,
+            "geometryX": 795,
             "geometryY": 270
         },
         {
             "PObject": {
                 "_id": "1089300470"
             },
-            "_boxTitle": "EL Net Status (0x21B4)",
+            "_boxTitle": "EL Net Status Word (0x21B4)",
             "_style": "(P512511192)",
-            "cellHeight": 18,
+            "cellHeight": 10,
             "cellWidth": 16,
-            "cellX": 69,
+            "cellX": 70,
             "cellY": 0,
             "dataItems": [
                 {
@@ -3089,20 +3098,20 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 270,
+            "geometryHeight": 150,
             "geometryWidth": 240,
-            "geometryX": 1035,
+            "geometryX": 1050,
             "geometryY": 0
         },
         {
             "PObject": {
                 "_id": "1077770104"
             },
-            "_boxTitle": "PIV Net Status (0x21B4)",
+            "_boxTitle": "PIV Net Status Word (0x21B4)",
             "_style": "(P1771970462)",
-            "cellHeight": 18,
+            "cellHeight": 10,
             "cellWidth": 17,
-            "cellX": 85,
+            "cellX": 86,
             "cellY": 0,
             "dataItems": [
                 {
@@ -3258,20 +3267,20 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 270,
+            "geometryHeight": 150,
             "geometryWidth": 255,
-            "geometryX": 1275,
+            "geometryX": 1290,
             "geometryY": 0
         },
         {
             "PObject": {
                 "_id": "455212370"
             },
-            "_boxTitle": "RW Net Status (0x21B4)",
+            "_boxTitle": "RW Net Status Word (0x21B4)",
             "_style": "(P63343233)",
-            "cellHeight": 18,
+            "cellHeight": 10,
             "cellWidth": 16,
-            "cellX": 102,
+            "cellX": 103,
             "cellY": 0,
             "dataItems": [
                 {
@@ -3427,20 +3436,20 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 270,
+            "geometryHeight": 150,
             "geometryWidth": 240,
-            "geometryX": 1530,
+            "geometryX": 1545,
             "geometryY": 0
         },
         {
             "PObject": {
                 "_id": "1879906532"
             },
-            "_boxTitle": "EL ECAT CTL Status (0x6041)",
+            "_boxTitle": "EL ECAT Status Word (0x6041)",
             "_style": "(P512511192)",
             "cellHeight": 15,
             "cellWidth": 16,
-            "cellX": 69,
+            "cellX": 70,
             "cellY": 18,
             "dataItems": [
                 {
@@ -3691,20 +3700,20 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 225,
-            "geometryWidth": 240,
-            "geometryX": 1035,
+            "geometryHeight": 226,
+            "geometryWidth": 241,
+            "geometryX": 1050,
             "geometryY": 270
         },
         {
             "PObject": {
                 "_id": "1099617157"
             },
-            "_boxTitle": "PIV ECAT CTL Status (0x6041)",
+            "_boxTitle": "PIV ECAT Status Word (0x6041)",
             "_style": "(P1771970462)",
             "cellHeight": 15,
             "cellWidth": 17,
-            "cellX": 85,
+            "cellX": 86,
             "cellY": 18,
             "dataItems": [
                 {
@@ -3955,20 +3964,20 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 225,
-            "geometryWidth": 255,
-            "geometryX": 1275,
+            "geometryHeight": 226,
+            "geometryWidth": 256,
+            "geometryX": 1290,
             "geometryY": 270
         },
         {
             "PObject": {
                 "_id": "1977967560"
             },
-            "_boxTitle": "RW ECAT CTL Status (0x6041)",
+            "_boxTitle": "RW ECAT Status Word (0x6041)",
             "_style": "(P63343233)",
             "cellHeight": 15,
             "cellWidth": 16,
-            "cellX": 102,
+            "cellX": 103,
             "cellY": 18,
             "dataItems": [
                 {
@@ -4221,7 +4230,7 @@
             ],
             "geometryHeight": 225,
             "geometryWidth": 240,
-            "geometryX": 1530,
+            "geometryX": 1545,
             "geometryY": 270
         },
         {
@@ -4230,10 +4239,10 @@
             },
             "_boxTitle": "EL Misc. Status",
             "_style": "(P512511192)",
-            "cellHeight": 15,
+            "cellHeight": 8,
             "cellWidth": 16,
-            "cellX": 69,
-            "cellY": 33,
+            "cellX": 70,
+            "cellY": 10,
             "dataItems": [
                 {
                     "PObject": {
@@ -4324,10 +4333,10 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 225,
+            "geometryHeight": 120,
             "geometryWidth": 240,
-            "geometryX": 1035,
-            "geometryY": 495
+            "geometryX": 1050,
+            "geometryY": 150
         },
         {
             "PObject": {
@@ -4335,10 +4344,10 @@
             },
             "_boxTitle": "PIV Misc. Status",
             "_style": "(P1771970462)",
-            "cellHeight": 15,
+            "cellHeight": 8,
             "cellWidth": 17,
-            "cellX": 85,
-            "cellY": 33,
+            "cellX": 86,
+            "cellY": 10,
             "dataItems": [
                 {
                     "PObject": {
@@ -4429,10 +4438,10 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 225,
+            "geometryHeight": 120,
             "geometryWidth": 255,
-            "geometryX": 1275,
-            "geometryY": 495
+            "geometryX": 1290,
+            "geometryY": 150
         },
         {
             "PObject": {
@@ -4440,10 +4449,10 @@
             },
             "_boxTitle": "RW Misc. Status",
             "_style": "(P63343233)",
-            "cellHeight": 15,
+            "cellHeight": 8,
             "cellWidth": 16,
-            "cellX": 102,
-            "cellY": 33,
+            "cellX": 103,
+            "cellY": 10,
             "dataItems": [
                 {
                     "PObject": {
@@ -4534,10 +4543,1004 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 225,
+            "geometryHeight": 120,
             "geometryWidth": 240,
-            "geometryX": 1530,
-            "geometryY": 495
+            "geometryX": 1545,
+            "geometryY": 150
+        },
+        {
+            "PObject": {
+                "_id": "1895438102"
+            },
+            "_boxTitle": "PIV ECAT CTL Word Read (0x6040)",
+            "_style": "(P1771970462)",
+            "cellHeight": 9,
+            "cellWidth": 17,
+            "cellX": 36,
+            "cellY": 58,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1015709642"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2076857633"
+                    },
+                    "_caption": "CTL_ON_READ_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ON_READ_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1026315882"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "120984325"
+                    },
+                    "_caption": "CTL_ENABLE_VOLTAGE_READ_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_VOLTAGE_READ_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "88732317"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "993687379"
+                    },
+                    "_caption": "CTL_QUICK_STOP_READ_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_QUICK_STOP_READ_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "499690176"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1115281789"
+                    },
+                    "_caption": "CTL_ENABLE_READ_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_READ_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "2111720275"
+                    },
+                    "_caption": "CTL_MODE_OF_OPERATION_READ_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "CTL_MODE_OF_OPERATION_READ_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1026971031"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "8162592"
+                    },
+                    "_caption": "CTL_RESET_FAULT_READ_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_RESET_FAULT_READ_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2073058547"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "406130053"
+                    },
+                    "_caption": "CTL_HALT_READ_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_HALT_READ_PIV",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 135,
+            "geometryWidth": 255,
+            "geometryX": 540,
+            "geometryY": 870
+        },
+        {
+            "PObject": {
+                "_id": "1151841207"
+            },
+            "_boxTitle": "RW ECAT CTL Word Read (0x6040)",
+            "_style": "(P63343233)",
+            "cellHeight": 9,
+            "cellWidth": 17,
+            "cellX": 53,
+            "cellY": 58,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1638219307"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "183280300"
+                    },
+                    "_caption": "CTL_ON_READ_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ON_READ_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1950683805"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1693834716"
+                    },
+                    "_caption": "CTL_ENABLE_VOLTAGE_READ_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_VOLTAGE_READ_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "952813783"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "742481146"
+                    },
+                    "_caption": "CTL_QUICK_STOP_READ_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_QUICK_STOP_READ_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1172874119"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "616851394"
+                    },
+                    "_caption": "CTL_ENABLE_READ_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_READ_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "243122376"
+                    },
+                    "_caption": "CTL_MODE_OF_OPERATION_READ_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "CTL_MODE_OF_OPERATION_READ_RW",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1880295860"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1695212388"
+                    },
+                    "_caption": "CTL_RESET_FAULT_READ_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_RESET_FAULT_READ_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "193620026"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "365117605"
+                    },
+                    "_caption": "CTL_HALT_READ_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_HALT_READ_RW",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 135,
+            "geometryWidth": 255,
+            "geometryX": 795,
+            "geometryY": 870
+        },
+        {
+            "PObject": {
+                "_id": "27798620"
+            },
+            "_boxTitle": "EL ECAT CTL Word Write (0x6040)",
+            "_style": "(P512511192)",
+            "cellHeight": 18,
+            "cellWidth": 16,
+            "cellX": 20,
+            "cellY": 49,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "832110412"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2142251293"
+                    },
+                    "_caption": "CTL_ON_WRITE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ON_WRITE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "623107386"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "267564164"
+                    },
+                    "_caption": "CTL_ENABLE_VOLTAGE_WRITE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_VOLTAGE_WRITE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "238320975"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "360669724"
+                    },
+                    "_caption": "CTL_QUICK_STOP_WRITE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_QUICK_STOP_WRITE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "400535798"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2069370893"
+                    },
+                    "_caption": "CTL_ENABLE_WRITE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_WRITE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "468231317"
+                    },
+                    "_caption": "CTL_MODE_OF_OPERATION_WRITE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "CTL_MODE_OF_OPERATION_WRITE_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1396274513"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1876001879"
+                    },
+                    "_caption": "CTL_RESET_FAULT_WRITE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_RESET_FAULT_WRITE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1110294595"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "792755928"
+                    },
+                    "_caption": "CTL_HALT_WRITE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_HALT_WRITE_EL",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 270,
+            "geometryWidth": 240,
+            "geometryX": 300,
+            "geometryY": 735
+        },
+        {
+            "PObject": {
+                "_id": "1837390292"
+            },
+            "_boxTitle": "PIV ECAT CTL Word Write (0x6040)",
+            "_style": "(P1771970462)",
+            "cellHeight": 9,
+            "cellWidth": 17,
+            "cellX": 36,
+            "cellY": 49,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1468078434"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "281017066"
+                    },
+                    "_caption": "CTL_ON_WRITE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ON_WRITE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1670219908"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "801220261"
+                    },
+                    "_caption": "CTL_ENABLE_VOLTAGE_WRITE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_VOLTAGE_WRITE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "827750769"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "206619747"
+                    },
+                    "_caption": "CTL_QUICK_STOP_WRITE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_QUICK_STOP_WRITE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "361798861"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "276634317"
+                    },
+                    "_caption": "CTL_ENABLE_WRITE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_WRITE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1424263357"
+                    },
+                    "_caption": "CTL_MODE_OF_OPERATION_WRITE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "CTL_MODE_OF_OPERATION_WRITE_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "532907613"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1055801927"
+                    },
+                    "_caption": "CTL_RESET_FAULT_WRITE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_RESET_FAULT_WRITE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1011542611"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1075030689"
+                    },
+                    "_caption": "CTL_HALT_WRITE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_HALT_WRITE_PIV",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 135,
+            "geometryWidth": 255,
+            "geometryX": 540,
+            "geometryY": 735
+        },
+        {
+            "PObject": {
+                "_id": "1592164032"
+            },
+            "_boxTitle": "RW ECAT CTL Word Write (0x6040)",
+            "_style": "(P63343233)",
+            "cellHeight": 9,
+            "cellWidth": 17,
+            "cellX": 53,
+            "cellY": 49,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1345030719"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "837693742"
+                    },
+                    "_caption": "CTL_ON_WRITE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ON_WRITE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "450535254"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1104737098"
+                    },
+                    "_caption": "CTL_ENABLE_VOLTAGE_WRITE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_VOLTAGE_WRITE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "156988624"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "220352665"
+                    },
+                    "_caption": "CTL_QUICK_STOP_WRITE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_QUICK_STOP_WRITE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "400261287"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1675562488"
+                    },
+                    "_caption": "CTL_ENABLE_WRITE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_WRITE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "102212718"
+                    },
+                    "_caption": "CTL_MODE_OF_OPERATION_WRITE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "CTL_MODE_OF_OPERATION_WRITE_RW",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1600203233"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1140173419"
+                    },
+                    "_caption": "CTL_RESET_FAULT_WRITE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_RESET_FAULT_WRITE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "62959602"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "570961200"
+                    },
+                    "_caption": "CTL_HALT_WRITE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_HALT_WRITE_RW",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 135,
+            "geometryWidth": 255,
+            "geometryX": 795,
+            "geometryY": 735
+        },
+        {
+            "PObject": {
+                "_id": "1205229836"
+            },
+            "_boxTitle": "EL ECAT CTL Word Read (0x6040)",
+            "_style": "(P512511192)",
+            "cellHeight": 9,
+            "cellWidth": 16,
+            "cellX": 20,
+            "cellY": 58,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1580300116"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "169932679"
+                    },
+                    "_caption": "CTL_ON_READ_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ON_READ_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "526602621"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1900274349"
+                    },
+                    "_caption": "CTL_ENABLE_VOLTAGE_READ_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_VOLTAGE_READ_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1264889504"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_WARN (P527972465)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2018672399"
+                    },
+                    "_caption": "CTL_QUICK_STOP_READ_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_QUICK_STOP_READ_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "904116332"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "226196080"
+                    },
+                    "_caption": "CTL_ENABLE_READ_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_ENABLE_READ_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1569315943"
+                    },
+                    "_caption": "CTL_MODE_OF_OPERATION_READ_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "CTL_MODE_OF_OPERATION_READ_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "857187385"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1628281135"
+                    },
+                    "_caption": "CTL_RESET_FAULT_READ_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_RESET_FAULT_READ_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1549306616"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_WARN (P527972465)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1724834586"
+                    },
+                    "_caption": "CTL_HALT_READ_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "CTL_HALT_READ_EL",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 135,
+            "geometryWidth": 240,
+            "geometryX": 300,
+            "geometryY": 870
+        },
+        {
+            "PObject": {
+                "_id": "866577093"
+            },
+            "_boxTitle": "ECAT AL State Machine (0x0130)",
+            "_style": "(P2072147126)",
+            "cellHeight": 5,
+            "cellWidth": 17,
+            "cellX": 3,
+            "cellY": 24,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1265800558"
+                        },
+                        "_map": {
+                            "1": "INIT[style=TIM_WARN (P527972465)]",
+                            "2": "PRE-OP[style=TIM_WARN (P527972465)]",
+                            "3": "BOOTSTRAP[style=TIM_WARN (P527972465)]",
+                            "4": "SAFE-OP[style=TIM_WARN (P527972465)]",
+                            "8": "OP[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1856379937"
+                    },
+                    "_caption": "STATE_EL_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_EL_MC",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1232513765"
+                        },
+                        "_map": {
+                            "1": "INIT[style=TIM_WARN (P527972465)]",
+                            "2": "PRE-OP[style=TIM_WARN (P527972465)]",
+                            "3": "BOOTSTRAP[style=TIM_WARN (P527972465)]",
+                            "4": "SAFE-OP[style=TIM_WARN (P527972465)]",
+                            "8": "OP[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1254010774"
+                    },
+                    "_caption": "STATE_PIV_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_PIV_MC",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "88071802"
+                        },
+                        "_map": {
+                            "1": "INIT[style=TIM_WARN (P527972465)]",
+                            "2": "PRE-OP[style=TIM_WARN (P527972465)]",
+                            "3": "BOOTSTRAP[style=TIM_WARN (P527972465)]",
+                            "4": "SAFE-OP[style=TIM_WARN (P527972465)]",
+                            "8": "OP[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "784993827"
+                    },
+                    "_caption": "STATE_RW_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_RW_MC",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 75,
+            "geometryWidth": 255,
+            "geometryX": 45,
+            "geometryY": 360
+        },
+        {
+            "PObject": {
+                "_id": "856286341"
+            },
+            "_boxTitle": "ECAT AL State Mach. Status Code",
+            "_style": "(P2072147126)",
+            "cellHeight": 5,
+            "cellWidth": 17,
+            "cellX": 3,
+            "cellY": 29,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1180212602"
+                    },
+                    "_caption": "STATUS_EC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "STATUS_EC_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1596323526"
+                    },
+                    "_caption": "STATUS_EC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "STATUS_EC_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "124701892"
+                    },
+                    "_caption": "STATUS_EC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "STATUS_EC_RW",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 75,
+            "geometryWidth": 255,
+            "geometryX": 45,
+            "geometryY": 435
         }
     ],
     "extremas": [
@@ -5107,6 +6110,17 @@
             "_italic": false,
             "_linked": true,
             "_name": "TIM_EL"
+        },
+        {
+            "PObject": {
+                "_id": "527972465"
+            },
+            "_bg": "#ffaa00",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_WARN"
         }
     ],
     "webPort": "\u0000",

--- a/owl/owl-files/tim/motor_controller_status.owl
+++ b/owl/owl-files/tim/motor_controller_status.owl
@@ -1,0 +1,5117 @@
+{
+    "OWL FILE rev.": "20140928",
+    "PObject": {
+        "_id": "0"
+    },
+    "boxes": [
+        {
+            "PObject": {
+                "_id": "1371110930"
+            },
+            "_boxTitle": "Flight Computers",
+            "_style": "(P695404123)",
+            "cellHeight": 18,
+            "cellWidth": 16,
+            "cellX": 3,
+            "cellY": 0,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1647403610"
+                        },
+                        "_map": {
+                            "0": "FC1[style=Bold (P1059175281)]",
+                            "1": "FC2[style=Bold (P1059175281)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "385035989"
+                    },
+                    "_caption": "InCharge  ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "SOUTH_I_AM",
+                    "type": "PMDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1864783427"
+                    },
+                    "_caption": "Plover",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "PLOVER",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "80969314"
+                    },
+                    "_caption": "Cmd Count FC1  ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "COUNT_CMD_N",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1845922756"
+                    },
+                    "_caption": "Cmd Count FC2 ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "COUNT_CMD_S",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1755922305"
+                    },
+                    "_caption": "Last Cmd FC2",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "LAST_CMD_S",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1654977475"
+                    },
+                    "_caption": "Date",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "%B %d, %Y",
+                    "_source": "TIME",
+                    "type": "PTDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "2079314512"
+                    },
+                    "_caption": "Time (UTC)",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "%H:%M:%S",
+                    "_source": "TIME",
+                    "type": "PTDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "22588231"
+                    },
+                    "_caption": "FC1 HDD Space",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "%d",
+                    "_source": "HDD_DISK_SPACE_N",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "718646907"
+                    },
+                    "_caption": "FC2 HDD Space",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "%d",
+                    "_source": "HDD_DISK_SPACE_S",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1599063661"
+                    },
+                    "_caption": "FC1 HDD Index",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "HDD_DISK_INDEX_N",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "737453770"
+                    },
+                    "_caption": "FC2 HDD Index",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "HDD_DISK_INDEX_S",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1925281899"
+                    },
+                    "_caption": "Last Cmd FC1",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "LAST_CMD_N",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 270,
+            "geometryWidth": 240,
+            "geometryX": 45,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "304550719"
+            },
+            "_boxTitle": "EtherCAT Network",
+            "_style": "(P2072147126)",
+            "cellHeight": 6,
+            "cellWidth": 17,
+            "cellX": 3,
+            "cellY": 18,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "691366938"
+                    },
+                    "_caption": "Nodes Discovered ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "N_FOUND_EC",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "423608236"
+                        },
+                        "_map": {
+                            "0": " READY[style=TIM_GOOD (P1165535148)]",
+                            "1": " NOT READY[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1770545002"
+                    },
+                    "_caption": "NETWORK_PROBLEM_RW",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NETWORK_PROBLEM_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1258234295"
+                        },
+                        "_map": {
+                            "0": "READY[style=TIM_GOOD (P1165535148)]",
+                            "1": "NOT READY[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "375282940"
+                    },
+                    "_caption": "NETWORK_PROBLEM_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NETWORK_PROBLEM_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1503625509"
+                        },
+                        "_map": {
+                            "0": "READY[style=TIM_GOOD (P1165535148)]",
+                            "1": "NOT READY[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1095149491"
+                    },
+                    "_caption": "NETWORK_PROBLEM_PIV",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NETWORK_PROBLEM_PIV",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 90,
+            "geometryWidth": 255,
+            "geometryX": 45,
+            "geometryY": 270
+        },
+        {
+            "PObject": {
+                "_id": "1112014480"
+            },
+            "_boxTitle": "EL Latched Faults (0x2183)",
+            "_style": "(P512511192)",
+            "cellHeight": 18,
+            "cellWidth": 16,
+            "cellX": 19,
+            "cellY": 0,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "839191018"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1200438989"
+                    },
+                    "_caption": "LATCHED_DATA_CRC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_DATA_CRC_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1202069143"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "605596517"
+                    },
+                    "_caption": "LATCHED_AMP_INT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_AMP_INT_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "577896241"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "71459813"
+                    },
+                    "_caption": "LATCHED_SHORT_CIRC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_SHORT_CIRC_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1552728350"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1964358428"
+                    },
+                    "_caption": "LATCHED_AMP_OVER_T_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_AMP_OVER_T_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "977163682"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "275935256"
+                    },
+                    "_caption": "LATCHED_MOTOR_OVER_T_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_MOTOR_OVER_T_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "202998721"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1337271114"
+                    },
+                    "_caption": "LATCHED_OVERVOLT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_OVERVOLT_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "901139208"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2130863777"
+                    },
+                    "_caption": "LATCHED_UNDERVOLT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_UNDERVOLT_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1880042921"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1609439383"
+                    },
+                    "_caption": "LATCHED_FEEDBACK_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_FEEDBACK_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "144971136"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1040401018"
+                    },
+                    "_caption": "LATCHED_PHASING_ERR_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_PHASING_ERR_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1608881234"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1399983930"
+                    },
+                    "_caption": "LATCHED_TRACKING_ERR_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_TRACKING_ERR_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1520455979"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "707436306"
+                    },
+                    "_caption": "LATCHED_OVERCURRENT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_OVERCURRENT_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1523059861"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1529442437"
+                    },
+                    "_caption": "LATCHED_FPGA_FAIL_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_FPGA_FAIL_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "371451664"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "519895286"
+                    },
+                    "_caption": "LATCHED_CMD_INPUT_LOST_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_CMD_INPUT_LOST_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1564106948"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1002304141"
+                    },
+                    "_caption": "LATCHED_FPGA_FAIL2_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_FPGA_FAIL2_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1096905644"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1923909329"
+                    },
+                    "_caption": "LATCHED_SAFETY_CIRC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_SAFETY_CIRC_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "834587605"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "375541092"
+                    },
+                    "_caption": "LATCHED_CONT_CURRENT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_CONT_CURRENT_EL",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 270,
+            "geometryWidth": 240,
+            "geometryX": 285,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "868005191"
+            },
+            "_boxTitle": "PIV Latched Faults (0x2183)",
+            "_style": "(P1771970462)",
+            "cellHeight": 18,
+            "cellWidth": 17,
+            "cellX": 35,
+            "cellY": 0,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2019638862"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2057437144"
+                    },
+                    "_caption": "LATCHED_DATA_CRC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_DATA_CRC_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1763572242"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "672384743"
+                    },
+                    "_caption": "LATCHED_AMP_INT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_AMP_INT_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2101811846"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "996442855"
+                    },
+                    "_caption": "LATCHED_SHORT_CIRC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_SHORT_CIRC_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1941703148"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "842199398"
+                    },
+                    "_caption": "LATCHED_AMP_OVER_T_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_AMP_OVER_T_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "395267734"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1028883793"
+                    },
+                    "_caption": "LATCHED_MOTOR_OVER_T_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_MOTOR_OVER_T_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1051014595"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1724067966"
+                    },
+                    "_caption": "LATCHED_OVERVOLT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_OVERVOLT_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "211315215"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1371838517"
+                    },
+                    "_caption": "LATCHED_UNDERVOLT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_UNDERVOLT_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "585689160"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1996903662"
+                    },
+                    "_caption": "LATCHED_FEEDBACK_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_FEEDBACK_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1528132839"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "179229605"
+                    },
+                    "_caption": "LATCHED_PHASING_ERR_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_PHASING_ERR_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1968730747"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "584480566"
+                    },
+                    "_caption": "LATCHED_TRACKING_ERR_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_TRACKING_ERR_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "260917059"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "8057746"
+                    },
+                    "_caption": "LATCHED_OVERCURRENT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_OVERCURRENT_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1181300694"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1883248981"
+                    },
+                    "_caption": "LATCHED_FPGA_FAIL_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_FPGA_FAIL_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "398835559"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "432521283"
+                    },
+                    "_caption": "LATCHED_CMD_INPUT_LOST_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_CMD_INPUT_LOST_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "831682138"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "373134"
+                    },
+                    "_caption": "LATCHED_FPGA_FAIL2_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_FPGA_FAIL2_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "221260629"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1069186380"
+                    },
+                    "_caption": "LATCHED_SAFETY_CIRC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_SAFETY_CIRC_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "392771975"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1035645928"
+                    },
+                    "_caption": "LATCHED_CONT_CURRENT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_CONT_CURRENT_PIV",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 270,
+            "geometryWidth": 255,
+            "geometryX": 525,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "2072621791"
+            },
+            "_boxTitle": "RW Latched Faults (0x2183)",
+            "_style": "(P63343233)",
+            "cellHeight": 18,
+            "cellWidth": 17,
+            "cellX": 52,
+            "cellY": 0,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "953893691"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1435961210"
+                    },
+                    "_caption": "LATCHED_DATA_CRC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_DATA_CRC_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1649808002"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1205482934"
+                    },
+                    "_caption": "LATCHED_AMP_INT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_AMP_INT_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "57090483"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "598499194"
+                    },
+                    "_caption": "LATCHED_SHORT_CIRC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_SHORT_CIRC_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1271900181"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "593185792"
+                    },
+                    "_caption": "LATCHED_AMP_OVER_T_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_AMP_OVER_T_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "980274525"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1483652968"
+                    },
+                    "_caption": "LATCHED_MOTOR_OVER_T_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_MOTOR_OVER_T_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1489751329"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1176918277"
+                    },
+                    "_caption": "LATCHED_OVERVOLT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_OVERVOLT_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "256917238"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1148998717"
+                    },
+                    "_caption": "LATCHED_UNDERVOLT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_UNDERVOLT_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2092337225"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2081417720"
+                    },
+                    "_caption": "LATCHED_FEEDBACK_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_FEEDBACK_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1451354624"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "906785918"
+                    },
+                    "_caption": "LATCHED_PHASING_ERR_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_PHASING_ERR_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "546419470"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "980039023"
+                    },
+                    "_caption": "LATCHED_TRACKING_ERR_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_TRACKING_ERR_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1704644085"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "820083916"
+                    },
+                    "_caption": "LATCHED_OVERCURRENT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_OVERCURRENT_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "999676023"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1891208583"
+                    },
+                    "_caption": "LATCHED_FPGA_FAIL_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_FPGA_FAIL_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1257806962"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1403758143"
+                    },
+                    "_caption": "LATCHED_CMD_INPUT_LOST_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_CMD_INPUT_LOST_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1135139146"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1942194718"
+                    },
+                    "_caption": "LATCHED_FPGA_FAIL2_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_FPGA_FAIL2_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1509740257"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1256463361"
+                    },
+                    "_caption": "LATCHED_SAFETY_CIRC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_SAFETY_CIRC_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1338374641"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1814384702"
+                    },
+                    "_caption": "LATCHED_CONT_CURRENT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_CONT_CURRENT_RW",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 270,
+            "geometryWidth": 255,
+            "geometryX": 780,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "1575341178"
+            },
+            "_boxTitle": "EL ECAT CTL Bitword (0x1002)",
+            "_style": "(P512511192)",
+            "cellHeight": 30,
+            "cellWidth": 16,
+            "cellX": 19,
+            "cellY": 18,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "826760854"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "121647512"
+                    },
+                    "_caption": "ST_SHORT_CIRC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_SHORT_CIRC_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "583217576"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1884571233"
+                    },
+                    "_caption": "ST_AMP_OVER_T_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_AMP_OVER_T_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1870046898"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1132482573"
+                    },
+                    "_caption": "ST_OVER_V_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_OVER_V_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1610876463"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1706195360"
+                    },
+                    "_caption": "ST_UNDER_V_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_UNDER_V_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1968146432"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "382371250"
+                    },
+                    "_caption": "ST_TEMP_SENS_ACTIVE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_TEMP_SENS_ACTIVE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "828880791"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1867359439"
+                    },
+                    "_caption": "ST_FEEDBACK_ERR_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_FEEDBACK_ERR_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1517673393"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1136835104"
+                    },
+                    "_caption": "ST_MOT_PHAS_ERR_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_MOT_PHAS_ERR_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1302873247"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "355219745"
+                    },
+                    "_caption": "ST_I_LIMITED_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_I_LIMITED_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "248976677"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1935903542"
+                    },
+                    "_caption": "ST_VOLT_LIM_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_VOLT_LIM_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1341999426"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1034686855"
+                    },
+                    "_caption": "ST_LIM_SW_POS_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_LIM_SW_POS_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2022790685"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "810080691"
+                    },
+                    "_caption": "ST_LIM_SW_NEG_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_LIM_SW_NEG_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "107769528"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "342693839"
+                    },
+                    "_caption": "ST_DISAB_HWARE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_DISAB_HWARE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1951800050"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "937493054"
+                    },
+                    "_caption": "ST_DISAB_SWARE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_DISAB_SWARE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1052015014"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "937652366"
+                    },
+                    "_caption": "ST_ATTEMPT_STOP_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_ATTEMPT_STOP_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "378259905"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "270940185"
+                    },
+                    "_caption": "ST_MOT_BREAK_ACT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_MOT_BREAK_ACT_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "289766768"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1077907461"
+                    },
+                    "_caption": "ST_PWM_OUT_DIS_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_PWM_OUT_DIS_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2068956473"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "770665217"
+                    },
+                    "_caption": "ST_POS_SOFT_LIM_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_POS_SOFT_LIM_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "151318470"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1870904448"
+                    },
+                    "_caption": "ST_NEG_SOFT_LIM_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_NEG_SOFT_LIM_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "224939120"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "701981923"
+                    },
+                    "_caption": "ST_FOLLOW_ERR_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_FOLLOW_ERR_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "605120052"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "358942288"
+                    },
+                    "_caption": "ST_FOLLOW_WARN_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_FOLLOW_WARN_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "101779808"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1824947245"
+                    },
+                    "_caption": "ST_AMP_HAS_RESET_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_AMP_HAS_RESET_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "746452410"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1718011279"
+                    },
+                    "_caption": "ST_ENCODER_WRAP_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_ENCODER_WRAP_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1269934168"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1523653744"
+                    },
+                    "_caption": "ST_AMP_FAULT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_AMP_FAULT_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1194082428"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1071519913"
+                    },
+                    "_caption": "ST_VEL_LIMITED_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_VEL_LIMITED_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "713056641"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1091796508"
+                    },
+                    "_caption": "ST_ACCEL_LIMITED_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_ACCEL_LIMITED_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1821902375"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "391621739"
+                    },
+                    "_caption": "ST_IN_MOTION_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_IN_MOTION_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "100046563"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1299231681"
+                    },
+                    "_caption": "ST_V_OUT_TRACK_W_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_V_OUT_TRACK_W_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "601893034"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1804404117"
+                    },
+                    "_caption": "ST_PHASE_NOT_INIT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_PHASE_NOT_INIT_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1725341610"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "672383951"
+                    },
+                    "_caption": "ST_CMD_FAULT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_CMD_FAULT_EL",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 450,
+            "geometryWidth": 240,
+            "geometryX": 285,
+            "geometryY": 270
+        },
+        {
+            "PObject": {
+                "_id": "898062968"
+            },
+            "_boxTitle": "PIV ECAT CTL Bitword (0x1002)",
+            "_style": "(P1771970462)",
+            "cellHeight": 30,
+            "cellWidth": 17,
+            "cellX": 35,
+            "cellY": 18,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "826312224"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1453664819"
+                    },
+                    "_caption": "ST_SHORT_CIRC_PIV",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_SHORT_CIRC_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "352021112"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1703588973"
+                    },
+                    "_caption": "ST_AMP_OVER_T_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_AMP_OVER_T_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "651920529"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1520482288"
+                    },
+                    "_caption": "ST_OVER_V_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_OVER_V_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "489171873"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1777975868"
+                    },
+                    "_caption": "ST_UNDER_V_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_UNDER_V_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "887549308"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1232782818"
+                    },
+                    "_caption": "ST_TEMP_SENS_ACTIVE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_TEMP_SENS_ACTIVE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "847929875"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "593888818"
+                    },
+                    "_caption": "ST_FEEDBACK_ERR_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_FEEDBACK_ERR_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2089891959"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1532167952"
+                    },
+                    "_caption": "ST_MOT_PHAS_ERR_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_MOT_PHAS_ERR_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1544153189"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "982951417"
+                    },
+                    "_caption": "ST_I_LIMITED_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_I_LIMITED_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1102512897"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "808682496"
+                    },
+                    "_caption": "ST_VOLT_LIM_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_VOLT_LIM_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1812889181"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "460311133"
+                    },
+                    "_caption": "ST_LIM_SW_POS_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_LIM_SW_POS_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "185032385"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "15040801"
+                    },
+                    "_caption": "ST_LIM_SW_NEG_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_LIM_SW_NEG_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1862750558"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "313768462"
+                    },
+                    "_caption": "ST_DISAB_HWARE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_DISAB_HWARE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "193572478"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1691885328"
+                    },
+                    "_caption": "ST_DISAB_SWARE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_DISAB_SWARE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1913652705"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "235737441"
+                    },
+                    "_caption": "ST_ATTEMPT_STOP_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_ATTEMPT_STOP_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "679058098"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2068130997"
+                    },
+                    "_caption": "ST_MOT_BREAK_ACT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_MOT_BREAK_ACT_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "394404281"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1770544397"
+                    },
+                    "_caption": "ST_PWM_OUT_DIS_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_PWM_OUT_DIS_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2074697947"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "846517496"
+                    },
+                    "_caption": "ST_POS_SOFT_LIM_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_POS_SOFT_LIM_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1431033309"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1992205439"
+                    },
+                    "_caption": "ST_NEG_SOFT_LIM_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_NEG_SOFT_LIM_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "150710597"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1449869337"
+                    },
+                    "_caption": "ST_FOLLOW_ERR_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_FOLLOW_ERR_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "375352741"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1424115398"
+                    },
+                    "_caption": "ST_FOLLOW_WARN_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_FOLLOW_WARN_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1846731540"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "332631072"
+                    },
+                    "_caption": "ST_AMP_HAS_RESET_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_AMP_HAS_RESET_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1625055825"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1531980370"
+                    },
+                    "_caption": "ST_ENCODER_WRAP_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_ENCODER_WRAP_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1706480078"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1934554606"
+                    },
+                    "_caption": "ST_AMP_FAULT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_AMP_FAULT_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "959733472"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "322113512"
+                    },
+                    "_caption": "ST_VEL_LIMITED_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_VEL_LIMITED_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1394024679"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1777193828"
+                    },
+                    "_caption": "ST_ACCEL_LIMITED_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_ACCEL_LIMITED_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1335380322"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1712684911"
+                    },
+                    "_caption": "ST_IN_MOTION_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_IN_MOTION_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "682212295"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1274374910"
+                    },
+                    "_caption": "ST_V_OUT_TRACK_W_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_V_OUT_TRACK_W_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "600543476"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1555448847"
+                    },
+                    "_caption": "ST_PHASE_NOT_INIT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_PHASE_NOT_INIT_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1248597690"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2099862790"
+                    },
+                    "_caption": "ST_CMD_FAULT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_CMD_FAULT_PIV",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 450,
+            "geometryWidth": 255,
+            "geometryX": 525,
+            "geometryY": 270
+        },
+        {
+            "PObject": {
+                "_id": "936106058"
+            },
+            "_boxTitle": "RW ECAT CTL Bitword (0x1002)",
+            "_style": "(P63343233)",
+            "cellHeight": 30,
+            "cellWidth": 17,
+            "cellX": 52,
+            "cellY": 18,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1236095467"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1930540935"
+                    },
+                    "_caption": "ST_SHORT_CIRC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_SHORT_CIRC_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2006122870"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1878639309"
+                    },
+                    "_caption": "ST_AMP_OVER_T_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_AMP_OVER_T_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1973244400"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1076963599"
+                    },
+                    "_caption": "ST_OVER_V_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_OVER_V_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "194718412"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "990753362"
+                    },
+                    "_caption": "ST_UNDER_V_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_UNDER_V_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1000063327"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1864026380"
+                    },
+                    "_caption": "ST_TEMP_SENS_ACTIVE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_TEMP_SENS_ACTIVE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2133299687"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "771956704"
+                    },
+                    "_caption": "ST_FEEDBACK_ERR_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_FEEDBACK_ERR_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "306331519"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "373350233"
+                    },
+                    "_caption": "ST_MOT_PHAS_ERR_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_MOT_PHAS_ERR_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "89103555"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "666611093"
+                    },
+                    "_caption": "ST_I_LIMITED_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_I_LIMITED_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1093158299"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1855442111"
+                    },
+                    "_caption": "ST_VOLT_LIM_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_VOLT_LIM_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "999652637"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2023560592"
+                    },
+                    "_caption": "ST_LIM_SW_POS_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_LIM_SW_POS_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "36198714"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "274892537"
+                    },
+                    "_caption": "ST_LIM_SW_NEG_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_LIM_SW_NEG_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "659845861"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1443918483"
+                    },
+                    "_caption": "ST_DISAB_HWARE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_DISAB_HWARE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1327195711"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2089587674"
+                    },
+                    "_caption": "ST_DISAB_SWARE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_DISAB_SWARE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1715974987"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1332008377"
+                    },
+                    "_caption": "ST_ATTEMPT_STOP_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_ATTEMPT_STOP_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1747139593"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1236849040"
+                    },
+                    "_caption": "ST_MOT_BREAK_ACT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_MOT_BREAK_ACT_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1263465816"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "197508719"
+                    },
+                    "_caption": "ST_PWM_OUT_DIS_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_PWM_OUT_DIS_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1596773880"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "222829336"
+                    },
+                    "_caption": "ST_POS_SOFT_LIM_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_POS_SOFT_LIM_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1599339049"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "388903356"
+                    },
+                    "_caption": "ST_NEG_SOFT_LIM_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_NEG_SOFT_LIM_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "745793654"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1805608276"
+                    },
+                    "_caption": "ST_FOLLOW_ERR_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_FOLLOW_ERR_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2051472256"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1937097573"
+                    },
+                    "_caption": "ST_FOLLOW_WARN_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_FOLLOW_WARN_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "596134894"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1851338912"
+                    },
+                    "_caption": "ST_AMP_HAS_RESET_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_AMP_HAS_RESET_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "121791766"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1894082121"
+                    },
+                    "_caption": "ST_ENCODER_WRAP_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_ENCODER_WRAP_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "318881160"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1347594747"
+                    },
+                    "_caption": "ST_AMP_FAULT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_AMP_FAULT_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "44058878"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1697176311"
+                    },
+                    "_caption": "ST_VEL_LIMITED_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_VEL_LIMITED_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "650374334"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "757289408"
+                    },
+                    "_caption": "ST_ACCEL_LIMITED_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_ACCEL_LIMITED_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1030974662"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "156041021"
+                    },
+                    "_caption": "ST_IN_MOTION_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_IN_MOTION_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1105395528"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "391873824"
+                    },
+                    "_caption": "ST_V_OUT_TRACK_W_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_V_OUT_TRACK_W_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "38867849"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "21355079"
+                    },
+                    "_caption": "ST_PHASE_NOT_INIT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_PHASE_NOT_INIT_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "844839990"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1436715248"
+                    },
+                    "_caption": "ST_CMD_FAULT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "ST_CMD_FAULT_RW",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 450,
+            "geometryWidth": 255,
+            "geometryX": 780,
+            "geometryY": 270
+        },
+        {
+            "PObject": {
+                "_id": "1089300470"
+            },
+            "_boxTitle": "EL Net Status (0x21B4)",
+            "_style": "(P512511192)",
+            "cellHeight": 18,
+            "cellWidth": 16,
+            "cellX": 69,
+            "cellY": 0,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2111799244"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "838554900"
+                    },
+                    "_caption": "NET_ST_NODE_STATUS_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_NODE_STATUS_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1753821469"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1907551328"
+                    },
+                    "_caption": "NET_ST_SYNC_MISSING_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_MISSING_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1867237488"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "615798065"
+                    },
+                    "_caption": "NET_ST_GUARD_ERR_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_GUARD_ERR_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1583070400"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1384635011"
+                    },
+                    "_caption": "NET_ST_BUS_OFF_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_BUS_OFF_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "598206209"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "333183552"
+                    },
+                    "_caption": "NET_ST_SYNC_TRANS_ERROR_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_TRANS_ERROR_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "94728413"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "946797077"
+                    },
+                    "_caption": "NET_ST_SYNC_REC_ERROR_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_REC_ERROR_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2063443686"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "642539460"
+                    },
+                    "_caption": "NET_ST_SYNC_TRANS_WARNING_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_TRANS_WARNING_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "623300194"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2051135399"
+                    },
+                    "_caption": "NET_ST_SYNC_REC_WARNING_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_REC_WARNING_EL",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 270,
+            "geometryWidth": 240,
+            "geometryX": 1035,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "1077770104"
+            },
+            "_boxTitle": "PIV Net Status (0x21B4)",
+            "_style": "(P1771970462)",
+            "cellHeight": 18,
+            "cellWidth": 17,
+            "cellX": 85,
+            "cellY": 0,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1195615719"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "101857962"
+                    },
+                    "_caption": "NET_ST_NODE_STATUS_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_NODE_STATUS_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1763132482"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2090842371"
+                    },
+                    "_caption": "NET_ST_SYNC_MISSING_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_MISSING_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "233854677"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1243624365"
+                    },
+                    "_caption": "NET_ST_GUARD_ERR_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_GUARD_ERR_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1994946493"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1225064835"
+                    },
+                    "_caption": "NET_ST_BUS_OFF_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_BUS_OFF_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "450977100"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "600464829"
+                    },
+                    "_caption": "NET_ST_SYNC_TRANS_ERROR_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_TRANS_ERROR_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "688542911"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "73864461"
+                    },
+                    "_caption": "NET_ST_SYNC_REC_ERROR_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_REC_ERROR_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "134683304"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "50452262"
+                    },
+                    "_caption": "NET_ST_SYNC_TRANS_WARNING_PIVOT ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_TRANS_WARNING_PIVOT",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "424894579"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "864767915"
+                    },
+                    "_caption": "NET_ST_SYNC_REC_WARNING_PIVOT ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_REC_WARNING_PIVOT",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 270,
+            "geometryWidth": 255,
+            "geometryX": 1275,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "455212370"
+            },
+            "_boxTitle": "RW Net Status (0x21B4)",
+            "_style": "(P63343233)",
+            "cellHeight": 18,
+            "cellWidth": 16,
+            "cellX": 102,
+            "cellY": 0,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1506484946"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "503636166"
+                    },
+                    "_caption": "NET_ST_NODE_STATUS_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_NODE_STATUS_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1194377836"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1443573652"
+                    },
+                    "_caption": "NET_ST_SYNC_MISSING_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_MISSING_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1283721600"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "319050547"
+                    },
+                    "_caption": "NET_ST_GUARD_ERR_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_GUARD_ERR_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1431077223"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "884719415"
+                    },
+                    "_caption": "NET_ST_BUS_OFF_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_BUS_OFF_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "397610415"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1422158384"
+                    },
+                    "_caption": "NET_ST_SYNC_TRANS_ERROR_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_TRANS_ERROR_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "842691321"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "990989226"
+                    },
+                    "_caption": "NET_ST_SYNC_REC_ERROR_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_REC_ERROR_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1925415292"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2064998164"
+                    },
+                    "_caption": "NET_ST_SYNC_TRANS_WARNING_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_TRANS_WARNING_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1926474129"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "776801619"
+                    },
+                    "_caption": "NET_ST_SYNC_REC_WARNING_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NET_ST_SYNC_REC_WARNING_RW",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 270,
+            "geometryWidth": 240,
+            "geometryX": 1530,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "1879906532"
+            },
+            "_boxTitle": "EL ECAT CTL Status (0x6041)",
+            "_style": "(P512511192)",
+            "cellHeight": 15,
+            "cellWidth": 16,
+            "cellX": 69,
+            "cellY": 18,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1238671176"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "899218540"
+                    },
+                    "_caption": "STATE_READY_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_READY_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1672298523"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1656636922"
+                    },
+                    "_caption": "STATE_SWITCHED_ON_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_SWITCHED_ON_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "235638829"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1759196650"
+                    },
+                    "_caption": "STATE_OP_ENABLED_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_OP_ENABLED_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1595953164"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1448520147"
+                    },
+                    "_caption": "STATE_FAULT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_FAULT_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "543783734"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1574310613"
+                    },
+                    "_caption": "STATE_VOLTAGE_ENABLED_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_VOLTAGE_ENABLED_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1517006282"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "292006633"
+                    },
+                    "_caption": "STATE_NOT_QUICK_STOP_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_NOT_QUICK_STOP_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1126391835"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "365359369"
+                    },
+                    "_caption": "STATE_ON_DISABLE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_ON_DISABLE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "913277158"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2069292539"
+                    },
+                    "_caption": "STATE_WARNING_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_WARNING_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1055583581"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1257388202"
+                    },
+                    "_caption": "STATE_ABORTED_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_ABORTED_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "360956835"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "730546082"
+                    },
+                    "_caption": "STATE_REMOTE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_REMOTE_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1524143561"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1527262544"
+                    },
+                    "_caption": "STATE_ON_TARGET_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_ON_TARGET_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1799822061"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1291570458"
+                    },
+                    "_caption": "STATE_AMP_LIMIT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_AMP_LIMIT_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1866830215"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "612283499"
+                    },
+                    "_caption": "STATE_MOVING_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_MOVING_EL",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 225,
+            "geometryWidth": 240,
+            "geometryX": 1035,
+            "geometryY": 270
+        },
+        {
+            "PObject": {
+                "_id": "1099617157"
+            },
+            "_boxTitle": "PIV ECAT CTL Status (0x6041)",
+            "_style": "(P1771970462)",
+            "cellHeight": 15,
+            "cellWidth": 17,
+            "cellX": 85,
+            "cellY": 18,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2104339725"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "266482648"
+                    },
+                    "_caption": "STATE_READY_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_READY_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1388744130"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "458878728"
+                    },
+                    "_caption": "STATE_SWITCHED_ON_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_SWITCHED_ON_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1304688062"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "218374478"
+                    },
+                    "_caption": "STATE_OP_ENABLED_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_OP_ENABLED_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "601577041"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1492008880"
+                    },
+                    "_caption": "STATE_FAULT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_FAULT_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "310789411"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "451471377"
+                    },
+                    "_caption": "STATE_VOLTAGE_ENABLED_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_VOLTAGE_ENABLED_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1686187286"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1942384086"
+                    },
+                    "_caption": "STATE_NOT_QUICK_STOP_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_NOT_QUICK_STOP_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1381242886"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "21293912"
+                    },
+                    "_caption": "STATE_ON_DISABLE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_ON_DISABLE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "984835629"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1050561697"
+                    },
+                    "_caption": "STATE_WARNING_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_WARNING_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1154568131"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "155153820"
+                    },
+                    "_caption": "STATE_ABORTED_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_ABORTED_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1893972529"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "662644557"
+                    },
+                    "_caption": "STATE_REMOTE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_REMOTE_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1613525092"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1274127275"
+                    },
+                    "_caption": "STATE_ON_TARGET_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_ON_TARGET_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "702725518"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1532806536"
+                    },
+                    "_caption": "STATE_AMP_LIMIT_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_AMP_LIMIT_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1870815555"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1759275013"
+                    },
+                    "_caption": "STATE_MOVING_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_MOVING_PIV",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 225,
+            "geometryWidth": 255,
+            "geometryX": 1275,
+            "geometryY": 270
+        },
+        {
+            "PObject": {
+                "_id": "1977967560"
+            },
+            "_boxTitle": "RW ECAT CTL Status (0x6041)",
+            "_style": "(P63343233)",
+            "cellHeight": 15,
+            "cellWidth": 16,
+            "cellX": 102,
+            "cellY": 18,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2046915665"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1349143140"
+                    },
+                    "_caption": "STATE_READY_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_READY_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "397545966"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "943466745"
+                    },
+                    "_caption": "STATE_SWITCHED_ON_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_SWITCHED_ON_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "292259375"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "27455194"
+                    },
+                    "_caption": "STATE_OP_ENABLED_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_OP_ENABLED_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "947888840"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "832213482"
+                    },
+                    "_caption": "STATE_FAULT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_FAULT_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1247645037"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1255612658"
+                    },
+                    "_caption": "STATE_VOLTAGE_ENABLED_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_VOLTAGE_ENABLED_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "338932867"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1042184559"
+                    },
+                    "_caption": "STATE_NOT_QUICK_STOP_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_NOT_QUICK_STOP_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1666950121"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1098000111"
+                    },
+                    "_caption": "STATE_ON_DISABLE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_ON_DISABLE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "834649477"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1284521348"
+                    },
+                    "_caption": "STATE_WARNING_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_WARNING_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "441611755"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "424202900"
+                    },
+                    "_caption": "STATE_ABORTED_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_ABORTED_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "210891607"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1118345483"
+                    },
+                    "_caption": "STATE_REMOTE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_REMOTE_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1818952995"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "876274717"
+                    },
+                    "_caption": "STATE_ON_TARGET_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_ON_TARGET_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "89620914"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "663630403"
+                    },
+                    "_caption": "STATE_AMP_LIMIT_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_AMP_LIMIT_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1743537521"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1059074636"
+                    },
+                    "_caption": "STATE_MOVING_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_MOVING_RW",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 225,
+            "geometryWidth": 240,
+            "geometryX": 1530,
+            "geometryY": 270
+        },
+        {
+            "PObject": {
+                "_id": "302924420"
+            },
+            "_boxTitle": "EL Misc. Status",
+            "_style": "(P512511192)",
+            "cellHeight": 15,
+            "cellWidth": 16,
+            "cellX": 69,
+            "cellY": 33,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "4269365"
+                    },
+                    "_caption": "INDEX_EC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "SLAVE_INDEX_EC_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "815355293"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "203327373"
+                    },
+                    "_caption": "COMMS_OK_EC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "COMMS_OK_EC_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1043454563"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1082549834"
+                    },
+                    "_caption": "SLAVE_ERROR_EC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "SLAVE_ERROR_EC_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "132796463"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1513753835"
+                    },
+                    "_caption": "HAS_DC_EC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "HAS_DC_EC_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1044713446"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "2126862825"
+                    },
+                    "_caption": "IS_MC_EC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "IS_MC_EC_EL",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 225,
+            "geometryWidth": 240,
+            "geometryX": 1035,
+            "geometryY": 495
+        },
+        {
+            "PObject": {
+                "_id": "167551583"
+            },
+            "_boxTitle": "PIV Misc. Status",
+            "_style": "(P1771970462)",
+            "cellHeight": 15,
+            "cellWidth": 17,
+            "cellX": 85,
+            "cellY": 33,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "459048391"
+                    },
+                    "_caption": "INDEX_EC_PIV",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "SLAVE_INDEX_EC_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2066110278"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "988612215"
+                    },
+                    "_caption": "COMMS_OK_EC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "COMMS_OK_EC_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "298227933"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1921179011"
+                    },
+                    "_caption": "SLAVE_ERROR_EC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "SLAVE_ERROR_EC_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1172504805"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1177668002"
+                    },
+                    "_caption": "HAS_DC_EC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "HAS_DC_EC_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "433057285"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1047925470"
+                    },
+                    "_caption": "IS_MC_EC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "IS_MC_EC_PIV",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 225,
+            "geometryWidth": 255,
+            "geometryX": 1275,
+            "geometryY": 495
+        },
+        {
+            "PObject": {
+                "_id": "1832064540"
+            },
+            "_boxTitle": "RW Misc. Status",
+            "_style": "(P63343233)",
+            "cellHeight": 15,
+            "cellWidth": 16,
+            "cellX": 102,
+            "cellY": 33,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "416135592"
+                    },
+                    "_caption": "INDEX_EC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "SLAVE_INDEX_EC_RW",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1210182932"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1866611041"
+                    },
+                    "_caption": "COMMS_OK_EC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "COMMS_OK_EC_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1330596762"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "890144878"
+                    },
+                    "_caption": "SLAVE_ERROR_EC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "SLAVE_ERROR_EC_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1063552081"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "147900379"
+                    },
+                    "_caption": "HAS_DC_EC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "HAS_DC_EC_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "513427928"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "978436769"
+                    },
+                    "_caption": "IS_MC_EC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "IS_MC_EC_RW",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 225,
+            "geometryWidth": 240,
+            "geometryX": 1530,
+            "geometryY": 495
+        }
+    ],
+    "extremas": [
+        {
+            "PObject": {
+                "_id": "1555967448"
+            },
+            "_high": 1,
+            "_low": -1,
+            "_name": "closed",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 2,
+            "_xlow": -2
+        },
+        {
+            "PObject": {
+                "_id": "2562332"
+            },
+            "_high": 1,
+            "_low": -1,
+            "_name": "Hot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 2,
+            "_xlow": -2
+        },
+        {
+            "PObject": {
+                "_id": "441404878"
+            },
+            "_high": 1,
+            "_low": -1,
+            "_name": "Hot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 48,
+            "_xlow": -2
+        },
+        {
+            "PObject": {
+                "_id": "86393181"
+            },
+            "_high": 1,
+            "_low": -1,
+            "_name": "Cold",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 2,
+            "_xlow": -2
+        },
+        {
+            "PObject": {
+                "_id": "1093262273"
+            },
+            "_high": 48,
+            "_low": -33,
+            "_name": "pivot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 48,
+            "_xlow": -33
+        },
+        {
+            "PObject": {
+                "_id": "1541579599"
+            },
+            "_high": 100,
+            "_low": -100,
+            "_name": "If front",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 100,
+            "_xlow": -100
+        },
+        {
+            "PObject": {
+                "_id": "1307762888"
+            },
+            "_high": 40,
+            "_low": -5,
+            "_name": "cryo ",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 40,
+            "_xlow": -5
+        },
+        {
+            "PObject": {
+                "_id": "117858562"
+            },
+            "_high": 100,
+            "_low": -100,
+            "_name": "roach",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 100,
+            "_xlow": -100
+        },
+        {
+            "PObject": {
+                "_id": "668710617"
+            },
+            "_high": 40,
+            "_low": -3,
+            "_name": "elmot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 40,
+            "_xlow": -3
+        },
+        {
+            "PObject": {
+                "_id": "718546340"
+            },
+            "_high": 32,
+            "_low": -4,
+            "_name": "rw",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 32,
+            "_xlow": -4
+        },
+        {
+            "PObject": {
+                "_id": "254145452"
+            },
+            "_high": 40,
+            "_low": -27,
+            "_name": "sc",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 40,
+            "_xlow": -27
+        },
+        {
+            "PObject": {
+                "_id": "1987199696"
+            },
+            "_high": 75,
+            "_low": -40,
+            "_name": "switchgyro",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 75,
+            "_xlow": -40
+        },
+        {
+            "PObject": {
+                "_id": "1988624569"
+            },
+            "_high": 85,
+            "_low": -20,
+            "_name": "balmot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 85,
+            "_xlow": -20
+        },
+        {
+            "PObject": {
+                "_id": "608120398"
+            },
+            "_high": 45,
+            "_low": -40,
+            "_name": "battery",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 45,
+            "_xlow": -40
+        },
+        {
+            "PObject": {
+                "_id": "1062044342"
+            },
+            "_high": 100,
+            "_low": -55,
+            "_name": "power",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 100,
+            "_xlow": -55
+        },
+        {
+            "PObject": {
+                "_id": "115374106"
+            },
+            "_high": 85,
+            "_low": -20,
+            "_name": "actuator",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 85,
+            "_xlow": -20
+        },
+        {
+            "PObject": {
+                "_id": "154279869"
+            },
+            "_high": 60,
+            "_low": -20,
+            "_name": "fc",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 60,
+            "_xlow": -20
+        },
+        {
+            "PObject": {
+                "_id": "365504407"
+            },
+            "_high": 50,
+            "_low": -10,
+            "_name": "HDD",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 50,
+            "_xlow": -10
+        },
+        {
+            "PObject": {
+                "_id": "1808614005"
+            },
+            "_high": 85,
+            "_low": -40,
+            "_name": "LJ",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 85,
+            "_xlow": -40
+        },
+        {
+            "PObject": {
+                "_id": "2029340679"
+            },
+            "_high": 50,
+            "_low": -30,
+            "_name": "octo",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 50,
+            "_xlow": -30
+        }
+    ],
+    "linkNames": [
+        "/data/etc/mole.lnk",
+        "/data/etc/dialup.lnk",
+        "/data/etc/tdrss.lnk",
+        "/data/etc/pilot.lnk",
+        "/data/etc/packets.lnk"
+    ],
+    "linkSelected": 0,
+    "owls": [
+    ],
+    "styles": [
+        {
+            "PObject": {
+                "_id": "2072147126"
+            },
+            "_bg": "#aaff7f",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "defbox"
+        },
+        {
+            "PObject": {
+                "_id": "477273981"
+            },
+            "_bg": "#ffffff",
+            "_bold": false,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": ""
+        },
+        {
+            "PObject": {
+                "_id": "564751211"
+            },
+            "_bg": "#ff0000",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Important"
+        },
+        {
+            "PObject": {
+                "_id": "2146903282"
+            },
+            "_bg": "#aaffff",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "temperatures"
+        },
+        {
+            "PObject": {
+                "_id": "695404123"
+            },
+            "_bg": "#ffaaff",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "computers"
+        },
+        {
+            "PObject": {
+                "_id": "1059175281"
+            },
+            "_bg": "#ffffff",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Bold"
+        },
+        {
+            "PObject": {
+                "_id": "1145347128"
+            },
+            "_bg": "#ffff7f",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Pointing"
+        },
+        {
+            "PObject": {
+                "_id": "604285081"
+            },
+            "_bg": "#ffaa7f",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Roaches"
+        },
+        {
+            "PObject": {
+                "_id": "1055304642"
+            },
+            "_bg": "#00ff00",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Important Green"
+        },
+        {
+            "PObject": {
+                "_id": "1999017657"
+            },
+            "_bg": "#00aaff",
+            "_bold": true,
+            "_fg": "#ff5500",
+            "_italic": true,
+            "_linked": true,
+            "_name": "Green OK"
+        },
+        {
+            "PObject": {
+                "_id": "150990864"
+            },
+            "_bg": "#aaaaff",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Sunsensor Box"
+        },
+        {
+            "PObject": {
+                "_id": "338000295"
+            },
+            "_bg": "#ffffff",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "steppers status"
+        },
+        {
+            "PObject": {
+                "_id": "956360347"
+            },
+            "_bg": "#ffaaaa",
+            "_bold": true,
+            "_fg": "#000055",
+            "_italic": false,
+            "_linked": true,
+            "_name": "xhigh"
+        },
+        {
+            "PObject": {
+                "_id": "1913941534"
+            },
+            "_bg": "#ffffff",
+            "_bold": true,
+            "_fg": "#ff0000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "high"
+        },
+        {
+            "PObject": {
+                "_id": "2017040817"
+            },
+            "_bg": "#ffffff",
+            "_bold": false,
+            "_fg": "#00aa00",
+            "_italic": false,
+            "_linked": true,
+            "_name": "low"
+        },
+        {
+            "PObject": {
+                "_id": "949614266"
+            },
+            "_bg": "#00ff00",
+            "_bold": true,
+            "_fg": "#000033",
+            "_italic": false,
+            "_linked": true,
+            "_name": "xlow"
+        },
+        {
+            "PObject": {
+                "_id": "2059868534"
+            },
+            "_bg": "#ffff00",
+            "_bold": false,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "shutter"
+        },
+        {
+            "PObject": {
+                "_id": "515713862"
+            },
+            "_bg": "#ffffff",
+            "_bold": false,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Veto"
+        },
+        {
+            "PObject": {
+                "_id": "272768464"
+            },
+            "_bg": "#00ffb3",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Labjack box"
+        },
+        {
+            "PObject": {
+                "_id": "1740116402"
+            },
+            "_bg": "#00ff00",
+            "_bold": false,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Low Good"
+        },
+        {
+            "PObject": {
+                "_id": "1165535148"
+            },
+            "_bg": "#00ff00",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_GOOD"
+        },
+        {
+            "PObject": {
+                "_id": "1196047623"
+            },
+            "_bg": "#ff0000",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_BAD"
+        },
+        {
+            "PObject": {
+                "_id": "63343233"
+            },
+            "_bg": "#fee1c4",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_RW"
+        },
+        {
+            "PObject": {
+                "_id": "1771970462"
+            },
+            "_bg": "#cdefff",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_PIV"
+        },
+        {
+            "PObject": {
+                "_id": "512511192"
+            },
+            "_bg": "#feffaa",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_EL"
+        }
+    ],
+    "webPort": "\u0000",
+    "windowCellHeight": 92,
+    "windowCellWidth": 150,
+    "windowHeight": 1386,
+    "windowWidth": 2256
+}

--- a/owl/owl-files/tim/motor_controller_status.owl
+++ b/owl/owl-files/tim/motor_controller_status.owl
@@ -4253,7 +4253,7 @@
                     "_defaultStyle": "noStyle",
                     "_extrema": false,
                     "_format": "",
-                    "_source": "SLAVE_INDEX_EC_EL",
+                    "_source": "PERIPH_INDEX_EC_EL",
                     "type": "PNDI"
                 },
                 {
@@ -4288,10 +4288,10 @@
                     "PObject": {
                         "_id": "1082549834"
                     },
-                    "_caption": "SLAVE_ERROR_EC_EL ",
+                    "_caption": "PERIPH_ERROR_EC_EL ",
                     "_captionStyle": "noStyle",
                     "_defaultStyle": "noStyle",
-                    "_source": "SLAVE_ERROR_EC_EL",
+                    "_source": "PERIPH_ERROR_EC_EL",
                     "type": "PMDI"
                 },
                 {
@@ -4358,7 +4358,7 @@
                     "_defaultStyle": "noStyle",
                     "_extrema": false,
                     "_format": "",
-                    "_source": "SLAVE_INDEX_EC_PIV",
+                    "_source": "PERIPH_INDEX_EC_PIV",
                     "type": "PNDI"
                 },
                 {
@@ -4393,10 +4393,10 @@
                     "PObject": {
                         "_id": "1921179011"
                     },
-                    "_caption": "SLAVE_ERROR_EC_PIV ",
+                    "_caption": "PERIPH_ERROR_EC_PIV ",
                     "_captionStyle": "noStyle",
                     "_defaultStyle": "noStyle",
-                    "_source": "SLAVE_ERROR_EC_PIV",
+                    "_source": "PERIPH_ERROR_EC_PIV",
                     "type": "PMDI"
                 },
                 {
@@ -4463,7 +4463,7 @@
                     "_defaultStyle": "noStyle",
                     "_extrema": false,
                     "_format": "",
-                    "_source": "SLAVE_INDEX_EC_RW",
+                    "_source": "PERIPH_INDEX_EC_RW",
                     "type": "PNDI"
                 },
                 {
@@ -4498,10 +4498,10 @@
                     "PObject": {
                         "_id": "890144878"
                     },
-                    "_caption": "SLAVE_ERROR_EC_RW ",
+                    "_caption": "PERIPH_ERROR_EC_RW ",
                     "_captionStyle": "noStyle",
                     "_defaultStyle": "noStyle",
-                    "_source": "SLAVE_ERROR_EC_RW",
+                    "_source": "PERIPH_ERROR_EC_RW",
                     "type": "PMDI"
                 },
                 {

--- a/owl/owl-files/tim/pointing.owl
+++ b/owl/owl-files/tim/pointing.owl
@@ -1,0 +1,2332 @@
+{
+    "OWL FILE rev.": "20140928",
+    "PObject": {
+        "_id": "0"
+    },
+    "boxes": [
+        {
+            "PObject": {
+                "_id": "1371110930"
+            },
+            "_boxTitle": "Flight Computers",
+            "_style": "(P695404123)",
+            "cellHeight": 18,
+            "cellWidth": 17,
+            "cellX": 3,
+            "cellY": 0,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1647403610"
+                        },
+                        "_map": {
+                            "0": "FC1[style=Bold (P1059175281)]",
+                            "1": "FC2[style=Bold (P1059175281)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "385035989"
+                    },
+                    "_caption": "InCharge  ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "SOUTH_I_AM",
+                    "type": "PMDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1864783427"
+                    },
+                    "_caption": "Plover",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "PLOVER",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "80969314"
+                    },
+                    "_caption": "Cmd Count FC1  ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "COUNT_CMD_N",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1845922756"
+                    },
+                    "_caption": "Cmd Count FC2 ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "COUNT_CMD_S",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1755922305"
+                    },
+                    "_caption": "Last Cmd FC2",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "LAST_CMD_S",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1654977475"
+                    },
+                    "_caption": "Date",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "%B %d, %Y",
+                    "_source": "TIME",
+                    "type": "PTDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "2079314512"
+                    },
+                    "_caption": "Time (UTC)",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "%H:%M:%S",
+                    "_source": "TIME",
+                    "type": "PTDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "22588231"
+                    },
+                    "_caption": "FC1 HDD Space",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "%d",
+                    "_source": "HDD_DISK_SPACE_N",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "718646907"
+                    },
+                    "_caption": "FC2 HDD Space",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "%d",
+                    "_source": "HDD_DISK_SPACE_S",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1599063661"
+                    },
+                    "_caption": "FC1 HDD Index",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "HDD_DISK_INDEX_N",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "737453770"
+                    },
+                    "_caption": "FC2 HDD Index",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "HDD_DISK_INDEX_S",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1925281899"
+                    },
+                    "_caption": "Last Cmd FC1",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "LAST_CMD_N",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 270,
+            "geometryWidth": 255,
+            "geometryX": 45,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "304550719"
+            },
+            "_boxTitle": "EtherCAT Network",
+            "_style": "(P2072147126)",
+            "cellHeight": 6,
+            "cellWidth": 17,
+            "cellX": 3,
+            "cellY": 18,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "621882819"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_BAD (P1196047623)]",
+                            "1": "1[style=TIM_WARN (P527972465)]",
+                            "2": "2[style=TIM_WARN (P527972465)]",
+                            "3": "3[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "88366191"
+                    },
+                    "_caption": "Nodes Discovered",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "N_FOUND_EC",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1258234295"
+                        },
+                        "_map": {
+                            "0": "READY[style=TIM_GOOD (P1165535148)]",
+                            "1": "NOT READY[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "375282940"
+                    },
+                    "_caption": "NETWORK_PROBLEM_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NETWORK_PROBLEM_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1503625509"
+                        },
+                        "_map": {
+                            "0": "READY[style=TIM_GOOD (P1165535148)]",
+                            "1": "NOT READY[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1095149491"
+                    },
+                    "_caption": "NETWORK_PROBLEM_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NETWORK_PROBLEM_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "423608236"
+                        },
+                        "_map": {
+                            "0": "READY[style=TIM_GOOD (P1165535148)]",
+                            "1": "NOT READY[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1770545002"
+                    },
+                    "_caption": "NETWORK_PROBLEM_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "NETWORK_PROBLEM_RW",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 90,
+            "geometryWidth": 255,
+            "geometryX": 45,
+            "geometryY": 270
+        },
+        {
+            "PObject": {
+                "_id": "1112014480"
+            },
+            "_boxTitle": "Axis Modes",
+            "_style": "(P2072147126)",
+            "cellHeight": 4,
+            "cellWidth": 16,
+            "cellX": 20,
+            "cellY": 0,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "983509653"
+                        },
+                        "_map": {
+                            "0": "AXIS_VEL[style=Pointing (P1145347128)]",
+                            "1": "AXIS_POSITION[style=No style (P1816012374)]",
+                            "2": "AXIS_LOCK[style=No style (P1816012374)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1519021051"
+                    },
+                    "_caption": "MODE_AZ_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "MODE_AZ_MC",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1561689802"
+                        },
+                        "_map": {
+                            "0": "AXIS_VEL[style=Pointing (P1145347128)]",
+                            "1": "AXIS_POSITION[style=No style (P1816012374)]",
+                            "2": "AXIS_LOCK[style=No style (P1816012374)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "400247034"
+                    },
+                    "_caption": "MODE_EL_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "MODE_EL_MC",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 60,
+            "geometryWidth": 240,
+            "geometryX": 300,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "868005191"
+            },
+            "_boxTitle": "Axis Destinations",
+            "_style": "(P2072147126)",
+            "cellHeight": 4,
+            "cellWidth": 16,
+            "cellX": 20,
+            "cellY": 4,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1852874402"
+                    },
+                    "_caption": "DEST_AZ_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "DEST_AZ_MC",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1701328686"
+                    },
+                    "_caption": "DEST_EL_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "DEST_EL_MC",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 60,
+            "geometryWidth": 240,
+            "geometryX": 300,
+            "geometryY": 60
+        },
+        {
+            "PObject": {
+                "_id": "2072621791"
+            },
+            "_boxTitle": "PIV Gains",
+            "_style": "(P1771970462)",
+            "cellHeight": 8,
+            "cellWidth": 17,
+            "cellX": 53,
+            "cellY": 36,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "2112321686"
+                    },
+                    "_caption": "G_PE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_PE_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1356545346"
+                    },
+                    "_caption": "G_PV_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_PV_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "729032442"
+                    },
+                    "_caption": "G_IV_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_IV_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "310484393"
+                    },
+                    "_caption": "G_IE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_IE_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "103762090"
+                    },
+                    "_caption": "FRICT_OFF_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "FRICT_OFF_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "378629741"
+                    },
+                    "_caption": "SET_RW",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "SET_RW",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 120,
+            "geometryWidth": 255,
+            "geometryX": 795,
+            "geometryY": 540
+        },
+        {
+            "PObject": {
+                "_id": "866577093"
+            },
+            "_boxTitle": "ECAT AL State Machine (0x0130)",
+            "_style": "(P2072147126)",
+            "cellHeight": 5,
+            "cellWidth": 17,
+            "cellX": 3,
+            "cellY": 24,
+            "dataItems": [
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1265800558"
+                        },
+                        "_map": {
+                            "1": "INIT[style=TIM_WARN (P527972465)]",
+                            "2": "PRE-OP[style=TIM_WARN (P527972465)]",
+                            "3": "BOOTSTRAP[style=TIM_WARN (P527972465)]",
+                            "4": "SAFE-OP[style=TIM_WARN (P527972465)]",
+                            "8": "OP[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1856379937"
+                    },
+                    "_caption": "STATE_EL_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_EL_MC",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1232513765"
+                        },
+                        "_map": {
+                            "1": "INIT[style=TIM_WARN (P527972465)]",
+                            "2": "PRE-OP[style=TIM_WARN (P527972465)]",
+                            "3": "BOOTSTRAP[style=TIM_WARN (P527972465)]",
+                            "4": "SAFE-OP[style=TIM_WARN (P527972465)]",
+                            "8": "OP[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1254010774"
+                    },
+                    "_caption": "STATE_PIV_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_PIV_MC",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "88071802"
+                        },
+                        "_map": {
+                            "1": "INIT[style=TIM_WARN (P527972465)]",
+                            "2": "PRE-OP[style=TIM_WARN (P527972465)]",
+                            "3": "BOOTSTRAP[style=TIM_WARN (P527972465)]",
+                            "4": "SAFE-OP[style=TIM_WARN (P527972465)]",
+                            "8": "OP[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "784993827"
+                    },
+                    "_caption": "STATE_RW_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "STATE_RW_MC",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 75,
+            "geometryWidth": 255,
+            "geometryX": 45,
+            "geometryY": 360
+        },
+        {
+            "PObject": {
+                "_id": "856286341"
+            },
+            "_boxTitle": "ECAT AL State Mach. Status Code",
+            "_style": "(P2072147126)",
+            "cellHeight": 5,
+            "cellWidth": 17,
+            "cellX": 3,
+            "cellY": 29,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1180212602"
+                    },
+                    "_caption": "STATUS_EC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "STATUS_EC_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1596323526"
+                    },
+                    "_caption": "STATUS_EC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "STATUS_EC_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "124701892"
+                    },
+                    "_caption": "STATUS_EC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "0x%x",
+                    "_source": "STATUS_EC_RW",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 75,
+            "geometryWidth": 255,
+            "geometryX": 45,
+            "geometryY": 435
+        },
+        {
+            "PObject": {
+                "_id": "767373332"
+            },
+            "_boxTitle": "Axis Velocities",
+            "_style": "(P2072147126)",
+            "cellHeight": 4,
+            "cellWidth": 16,
+            "cellX": 20,
+            "cellY": 8,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "2080165516"
+                    },
+                    "_caption": "VEL_AZ_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "VEL_AZ_MC",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1776740057"
+                    },
+                    "_caption": "VEL_EL_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "VEL_EL_MC",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 60,
+            "geometryWidth": 240,
+            "geometryX": 300,
+            "geometryY": 120
+        },
+        {
+            "PObject": {
+                "_id": "964881208"
+            },
+            "_boxTitle": "Axis Directions",
+            "_style": "(P2072147126)",
+            "cellHeight": 4,
+            "cellWidth": 16,
+            "cellX": 20,
+            "cellY": 12,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1155455232"
+                    },
+                    "_caption": "DIR_AZ_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "DIR_AZ_MC",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "534223988"
+                    },
+                    "_caption": "DIR_EL_MC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "DIR_EL_MC",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 60,
+            "geometryWidth": 240,
+            "geometryX": 300,
+            "geometryY": 180
+        },
+        {
+            "PObject": {
+                "_id": "542491572"
+            },
+            "_boxTitle": "Axis Accel.",
+            "_style": "(P2072147126)",
+            "cellHeight": 3,
+            "cellWidth": 16,
+            "cellX": 20,
+            "cellY": 16,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "195080494"
+                    },
+                    "_caption": "ACCEL_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "ACCEL_AZ",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 45,
+            "geometryWidth": 240,
+            "geometryX": 300,
+            "geometryY": 240
+        },
+        {
+            "PObject": {
+                "_id": "14733779"
+            },
+            "_boxTitle": "EL Gains",
+            "_style": "(P512511192)",
+            "cellHeight": 8,
+            "cellWidth": 17,
+            "cellX": 36,
+            "cellY": 36,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "673255223"
+                    },
+                    "_caption": "G_P_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_P_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "832839382"
+                    },
+                    "_caption": "G_I_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_I_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1095936682"
+                    },
+                    "_caption": "G_D_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_D_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "847416624"
+                    },
+                    "_caption": "G_DB_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_DB_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "379349048"
+                    },
+                    "_caption": "FRICT_OFF_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "FRICT_OFF_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1425450108"
+                    },
+                    "_caption": "G_PT_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_PT_EL",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 120,
+            "geometryWidth": 255,
+            "geometryX": 540,
+            "geometryY": 540
+        },
+        {
+            "PObject": {
+                "_id": "397158952"
+            },
+            "_boxTitle": "RW Gains",
+            "_style": "(P63343233)",
+            "cellHeight": 8,
+            "cellWidth": 17,
+            "cellX": 70,
+            "cellY": 36,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "767981586"
+                    },
+                    "_caption": "G_P_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_P_AZ",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1376423292"
+                    },
+                    "_caption": "G_I_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_I_AZ",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "332173599"
+                    },
+                    "_caption": "G_D_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_D_AZ",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1238888827"
+                    },
+                    "_caption": "G_PT_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "G_PT_AZ",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 120,
+            "geometryWidth": 255,
+            "geometryX": 1050,
+            "geometryY": 540
+        },
+        {
+            "PObject": {
+                "_id": "1750391841"
+            },
+            "_boxTitle": "Temps",
+            "_style": "(P2072147126)",
+            "cellHeight": 5,
+            "cellWidth": 16,
+            "cellX": 20,
+            "cellY": 32,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "420465696"
+                    },
+                    "_caption": "T_MC_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": true,
+                    "_extremaID": "(P668710617)",
+                    "_format": "",
+                    "_source": "T_MC_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "431663819"
+                    },
+                    "_caption": "T_MC_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": true,
+                    "_extremaID": "(P1093262273)",
+                    "_format": "",
+                    "_source": "T_MC_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1957863755"
+                    },
+                    "_caption": "T_MC_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": true,
+                    "_extremaID": "(P718546340)",
+                    "_format": "",
+                    "_source": "T_MC_RW",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 75,
+            "geometryWidth": 240,
+            "geometryX": 300,
+            "geometryY": 480
+        },
+        {
+            "PObject": {
+                "_id": "1971406836"
+            },
+            "_boxTitle": "Tuning",
+            "_style": "(P527972465)",
+            "cellHeight": 3,
+            "cellWidth": 51,
+            "cellX": 36,
+            "cellY": 33,
+            "dataItems": [
+            ],
+            "geometryHeight": 45,
+            "geometryWidth": 765,
+            "geometryX": 540,
+            "geometryY": 495
+        },
+        {
+            "PObject": {
+                "_id": "36248387"
+            },
+            "_boxTitle": "ECAT Node Reset Status",
+            "_style": "(P2072147126)",
+            "cellHeight": 3,
+            "cellWidth": 17,
+            "cellX": 3,
+            "cellY": 34,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1694200219"
+                    },
+                    "_caption": "Bits ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_highWord": "",
+                    "_lowWord": "",
+                    "_nBits": 8,
+                    "_source": "MC_CMD_STATUS",
+                    "type": "PBDI"
+                }
+            ],
+            "geometryHeight": 45,
+            "geometryWidth": 256,
+            "geometryX": 45,
+            "geometryY": 510
+        },
+        {
+            "PObject": {
+                "_id": "266526295"
+            },
+            "_boxTitle": "PID Quantities",
+            "_style": "(P2072147126)",
+            "cellHeight": 3,
+            "cellWidth": 51,
+            "cellX": 36,
+            "cellY": 21,
+            "dataItems": [
+            ],
+            "geometryHeight": 45,
+            "geometryWidth": 765,
+            "geometryX": 540,
+            "geometryY": 315
+        },
+        {
+            "PObject": {
+                "_id": "2063740415"
+            },
+            "_boxTitle": "EL",
+            "_style": "(P512511192)",
+            "cellHeight": 9,
+            "cellWidth": 17,
+            "cellX": 36,
+            "cellY": 24,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "556410965"
+                    },
+                    "_caption": "P_TERM_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "P_TERM_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "2083202133"
+                    },
+                    "_caption": "I_TERM_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "I_TERM_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "180907621"
+                    },
+                    "_caption": "D_TERM_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "D_TERM_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "923264589"
+                    },
+                    "_caption": "ERROR_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "ERROR_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "176849428"
+                    },
+                    "_caption": "EL_INTEGRAL_STEP ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "EL_INTEGRAL_STEP",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1640312771"
+                    },
+                    "_caption": "FRICT_TERM_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "FRICT_TERM_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1815704051"
+                    },
+                    "_caption": "FRICT_TERM_UF_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "FRICT_TERM_UF_EL",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 135,
+            "geometryWidth": 255,
+            "geometryX": 540,
+            "geometryY": 360
+        },
+        {
+            "PObject": {
+                "_id": "1342155429"
+            },
+            "_boxTitle": "PIV",
+            "_style": "(P1771970462)",
+            "cellHeight": 9,
+            "cellWidth": 17,
+            "cellX": 53,
+            "cellY": 24,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1187465624"
+                    },
+                    "_caption": "P_RW_TERM_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "P_RW_TERM_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1667114027"
+                    },
+                    "_caption": "I_RW_TERM_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "I_RW_TERM_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "606493286"
+                    },
+                    "_caption": "P_ERR_TERM_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "P_ERR_TERM_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1540332602"
+                    },
+                    "_caption": "I_ERR_TERM_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "I_ERR_TERM_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1068721061"
+                    },
+                    "_caption": "FRICT_TERM_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "FRICT_TERM_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1382167297"
+                    },
+                    "_caption": "FRICT_TERM_UF_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "FRICT_TERM_UF_PIV",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 135,
+            "geometryWidth": 255,
+            "geometryX": 795,
+            "geometryY": 360
+        },
+        {
+            "PObject": {
+                "_id": "1898050563"
+            },
+            "_boxTitle": "RW",
+            "_style": "(P63343233)",
+            "cellHeight": 9,
+            "cellWidth": 17,
+            "cellX": 70,
+            "cellY": 24,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1954008743"
+                    },
+                    "_caption": "P_TERM_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "P_TERM_AZ",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "179289819"
+                    },
+                    "_caption": "I_TERM_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "I_TERM_AZ",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "139755539"
+                    },
+                    "_caption": "D_TERM_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "D_TERM_AZ",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "893487842"
+                    },
+                    "_caption": "ERROR_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "ERROR_AZ",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 135,
+            "geometryWidth": 255,
+            "geometryX": 1050,
+            "geometryY": 360
+        },
+        {
+            "PObject": {
+                "_id": "478141984"
+            },
+            "_boxTitle": "Pointing Algorithm",
+            "_style": "(P2072147126)",
+            "cellHeight": 13,
+            "cellWidth": 16,
+            "cellX": 20,
+            "cellY": 19,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1509491558"
+                    },
+                    "_caption": "VEL_REQ_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "VEL_REQ_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1755715423"
+                    },
+                    "_caption": "VEL_REQ_AZ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "VEL_REQ_AZ",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "600160810"
+                    },
+                    "_caption": "VEL_EL_P (Pointing El . Vel.) ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "VEL_EL_P",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "2014010095"
+                    },
+                    "_caption": "I_DITH_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "I_DITH_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1696596055"
+                    },
+                    "_caption": "DITH_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "DITH_EL",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 196,
+            "geometryWidth": 241,
+            "geometryX": 300,
+            "geometryY": 285
+        },
+        {
+            "PObject": {
+                "_id": "1384955355"
+            },
+            "_boxTitle": "EL",
+            "_style": "(P512511192)",
+            "cellHeight": 11,
+            "cellWidth": 17,
+            "cellX": 36,
+            "cellY": 3,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1828208802"
+                    },
+                    "_caption": "MC_EL_VEL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_EL_VEL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "774091524"
+                    },
+                    "_caption": "MC_EL_POS ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_EL_POS",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "2103980851"
+                    },
+                    "_caption": "MC_EL_MOTOR_POS ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_EL_MOTOR_POS",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "315541050"
+                    },
+                    "_caption": "MC_PHASE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PHASE_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1528000026"
+                    },
+                    "_caption": "MC_PHASE_MODE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PHASE_MODE_EL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "615915184"
+                    },
+                    "_caption": "EL_RAW_ENC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "EL_RAW_ENC",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1078237796"
+                    },
+                    "_caption": "EL_RAW_ENC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "EL_MOTOR_ENC",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1202982024"
+                    },
+                    "_caption": "SIGMA_MOTOR_ENC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "SIGMA_MOTOR_ENC",
+                    "type": "PNDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1190220619"
+                        },
+                        "_map": {
+                            "0": "0[style=No style (P1147542620)]",
+                            "1": "1[style=TIM_GOOD (P1165535148)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "808061480"
+                    },
+                    "_caption": "OK_MOTOR_ENC ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "OK_MOTOR_ENC",
+                    "type": "PMDI"
+                }
+            ],
+            "geometryHeight": 166,
+            "geometryWidth": 256,
+            "geometryX": 540,
+            "geometryY": 45
+        },
+        {
+            "PObject": {
+                "_id": "546853508"
+            },
+            "_boxTitle": "Currents",
+            "_style": "(P2072147126)",
+            "cellHeight": 3,
+            "cellWidth": 51,
+            "cellX": 36,
+            "cellY": 14,
+            "dataItems": [
+            ],
+            "geometryHeight": 45,
+            "geometryWidth": 765,
+            "geometryX": 540,
+            "geometryY": 210
+        },
+        {
+            "PObject": {
+                "_id": "296695744"
+            },
+            "_boxTitle": "EL",
+            "_style": "(P512511192)",
+            "cellHeight": 4,
+            "cellWidth": 17,
+            "cellX": 36,
+            "cellY": 17,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "332636465"
+                    },
+                    "_caption": "MC_EL_I_CMD ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": true,
+                    "_extremaID": "(P630033439)",
+                    "_format": "",
+                    "_source": "MC_EL_I_CMD",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "2107057043"
+                    },
+                    "_caption": "MC_EL_I_READ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": true,
+                    "_extremaID": "(P630033439)",
+                    "_format": "",
+                    "_source": "MC_EL_I_READ",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 60,
+            "geometryWidth": 255,
+            "geometryX": 540,
+            "geometryY": 255
+        },
+        {
+            "PObject": {
+                "_id": "231816781"
+            },
+            "_boxTitle": "PIV",
+            "_style": "(P1771970462)",
+            "cellHeight": 11,
+            "cellWidth": 17,
+            "cellX": 53,
+            "cellY": 3,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "76199607"
+                    },
+                    "_caption": "MC_PIV_VEL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PIV_VEL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1739225833"
+                    },
+                    "_caption": "MC_PIV_POS ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PIV_POS",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "444488925"
+                    },
+                    "_caption": "MC_PHASE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PHASE_PIV",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "415781498"
+                    },
+                    "_caption": "MC_PHASE_MODE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PHASE_MODE_PIV",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 166,
+            "geometryWidth": 256,
+            "geometryX": 795,
+            "geometryY": 45
+        },
+        {
+            "PObject": {
+                "_id": "1638034781"
+            },
+            "_boxTitle": "RW",
+            "_style": "(P63343233)",
+            "cellHeight": 11,
+            "cellWidth": 17,
+            "cellX": 70,
+            "cellY": 3,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1301670085"
+                    },
+                    "_caption": "MC_RW_VEL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_RW_VEL",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1840129109"
+                    },
+                    "_caption": "MC_RW_POS ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_RW_POS",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "653613325"
+                    },
+                    "_caption": "MC_RW_POS ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PHASE_RW",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1886552998"
+                    },
+                    "_caption": "MC_PHASE_MODE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PHASE_MODE_RW",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 166,
+            "geometryWidth": 256,
+            "geometryX": 1050,
+            "geometryY": 45
+        },
+        {
+            "PObject": {
+                "_id": "1376514758"
+            },
+            "_boxTitle": "PIV",
+            "_style": "(P1771970462)",
+            "cellHeight": 4,
+            "cellWidth": 17,
+            "cellX": 53,
+            "cellY": 17,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "575648491"
+                    },
+                    "_caption": "MC_PIV_I_CMD ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PIV_I_CMD",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "837400528"
+                    },
+                    "_caption": "MC_PIV_I_READ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_PIV_I_READ",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 60,
+            "geometryWidth": 255,
+            "geometryX": 795,
+            "geometryY": 255
+        },
+        {
+            "PObject": {
+                "_id": "452361591"
+            },
+            "_boxTitle": "RW",
+            "_style": "(P63343233)",
+            "cellHeight": 4,
+            "cellWidth": 17,
+            "cellX": 70,
+            "cellY": 17,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "1637538481"
+                    },
+                    "_caption": "MC_RW_I_CMD ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_RW_I_CMD",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1041937575"
+                    },
+                    "_caption": "MC_RW_I_READ ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MC_RW_I_READ",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 60,
+            "geometryWidth": 255,
+            "geometryX": 1050,
+            "geometryY": 255
+        },
+        {
+            "PObject": {
+                "_id": "1754541957"
+            },
+            "_boxTitle": "Motor Controller Reporting",
+            "_style": "(P2072147126)",
+            "cellHeight": 3,
+            "cellWidth": 51,
+            "cellX": 36,
+            "cellY": 0,
+            "dataItems": [
+            ],
+            "geometryHeight": 45,
+            "geometryWidth": 765,
+            "geometryX": 540,
+            "geometryY": 0
+        }
+    ],
+    "extremas": [
+        {
+            "PObject": {
+                "_id": "1555967448"
+            },
+            "_high": 1,
+            "_low": -1,
+            "_name": "closed",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 2,
+            "_xlow": -2
+        },
+        {
+            "PObject": {
+                "_id": "2562332"
+            },
+            "_high": 1,
+            "_low": -1,
+            "_name": "Hot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 2,
+            "_xlow": -2
+        },
+        {
+            "PObject": {
+                "_id": "441404878"
+            },
+            "_high": 1,
+            "_low": -1,
+            "_name": "Hot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 48,
+            "_xlow": -2
+        },
+        {
+            "PObject": {
+                "_id": "86393181"
+            },
+            "_high": 1,
+            "_low": -1,
+            "_name": "Cold",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 2,
+            "_xlow": -2
+        },
+        {
+            "PObject": {
+                "_id": "1093262273"
+            },
+            "_high": 48,
+            "_low": -33,
+            "_name": "pivot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 48,
+            "_xlow": -33
+        },
+        {
+            "PObject": {
+                "_id": "1541579599"
+            },
+            "_high": 100,
+            "_low": -100,
+            "_name": "If front",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 100,
+            "_xlow": -100
+        },
+        {
+            "PObject": {
+                "_id": "1307762888"
+            },
+            "_high": 40,
+            "_low": -5,
+            "_name": "cryo ",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 40,
+            "_xlow": -5
+        },
+        {
+            "PObject": {
+                "_id": "117858562"
+            },
+            "_high": 100,
+            "_low": -100,
+            "_name": "roach",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 100,
+            "_xlow": -100
+        },
+        {
+            "PObject": {
+                "_id": "668710617"
+            },
+            "_high": 40,
+            "_low": -3,
+            "_name": "elmot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 40,
+            "_xlow": -3
+        },
+        {
+            "PObject": {
+                "_id": "718546340"
+            },
+            "_high": 32,
+            "_low": -4,
+            "_name": "rw",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 32,
+            "_xlow": -4
+        },
+        {
+            "PObject": {
+                "_id": "254145452"
+            },
+            "_high": 40,
+            "_low": -27,
+            "_name": "sc",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 40,
+            "_xlow": -27
+        },
+        {
+            "PObject": {
+                "_id": "1987199696"
+            },
+            "_high": 75,
+            "_low": -40,
+            "_name": "switchgyro",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 75,
+            "_xlow": -40
+        },
+        {
+            "PObject": {
+                "_id": "1988624569"
+            },
+            "_high": 85,
+            "_low": -20,
+            "_name": "balmot",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 85,
+            "_xlow": -20
+        },
+        {
+            "PObject": {
+                "_id": "608120398"
+            },
+            "_high": 45,
+            "_low": -40,
+            "_name": "battery",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 45,
+            "_xlow": -40
+        },
+        {
+            "PObject": {
+                "_id": "1062044342"
+            },
+            "_high": 100,
+            "_low": -55,
+            "_name": "power",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 100,
+            "_xlow": -55
+        },
+        {
+            "PObject": {
+                "_id": "115374106"
+            },
+            "_high": 85,
+            "_low": -20,
+            "_name": "actuator",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 85,
+            "_xlow": -20
+        },
+        {
+            "PObject": {
+                "_id": "154279869"
+            },
+            "_high": 60,
+            "_low": -20,
+            "_name": "fc",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 60,
+            "_xlow": -20
+        },
+        {
+            "PObject": {
+                "_id": "365504407"
+            },
+            "_high": 50,
+            "_low": -10,
+            "_name": "HDD",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 50,
+            "_xlow": -10
+        },
+        {
+            "PObject": {
+                "_id": "1808614005"
+            },
+            "_high": 85,
+            "_low": -40,
+            "_name": "LJ",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 85,
+            "_xlow": -40
+        },
+        {
+            "PObject": {
+                "_id": "2029340679"
+            },
+            "_high": 50,
+            "_low": -30,
+            "_name": "octo",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P2017040817)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P949614266)",
+            "_xhigh": 50,
+            "_xlow": -30
+        },
+        {
+            "PObject": {
+                "_id": "630033439"
+            },
+            "_high": 15,
+            "_low": -15,
+            "_name": "TIM_BEL_current_limits",
+            "_shigh": "(P1913941534)",
+            "_slow": "(P1913941534)",
+            "_sxhigh": "(P956360347)",
+            "_sxlow": "(P956360347)",
+            "_xhigh": 30,
+            "_xlow": -30
+        }
+    ],
+    "linkNames": [
+        "/data/etc/mole.lnk",
+        "/data/etc/dialup.lnk",
+        "/data/etc/tdrss.lnk",
+        "/data/etc/pilot.lnk",
+        "/data/etc/packets.lnk"
+    ],
+    "linkSelected": 0,
+    "owls": [
+    ],
+    "styles": [
+        {
+            "PObject": {
+                "_id": "2072147126"
+            },
+            "_bg": "#aaff7f",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "defbox"
+        },
+        {
+            "PObject": {
+                "_id": "477273981"
+            },
+            "_bg": "#ffffff",
+            "_bold": false,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": ""
+        },
+        {
+            "PObject": {
+                "_id": "564751211"
+            },
+            "_bg": "#ff0000",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Important"
+        },
+        {
+            "PObject": {
+                "_id": "2146903282"
+            },
+            "_bg": "#aaffff",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "temperatures"
+        },
+        {
+            "PObject": {
+                "_id": "695404123"
+            },
+            "_bg": "#ffaaff",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "computers"
+        },
+        {
+            "PObject": {
+                "_id": "1059175281"
+            },
+            "_bg": "#ffffff",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Bold"
+        },
+        {
+            "PObject": {
+                "_id": "1145347128"
+            },
+            "_bg": "#ffff7f",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Pointing"
+        },
+        {
+            "PObject": {
+                "_id": "604285081"
+            },
+            "_bg": "#ffaa7f",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Roaches"
+        },
+        {
+            "PObject": {
+                "_id": "1055304642"
+            },
+            "_bg": "#00ff00",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Important Green"
+        },
+        {
+            "PObject": {
+                "_id": "1999017657"
+            },
+            "_bg": "#00aaff",
+            "_bold": true,
+            "_fg": "#ff5500",
+            "_italic": true,
+            "_linked": true,
+            "_name": "Green OK"
+        },
+        {
+            "PObject": {
+                "_id": "150990864"
+            },
+            "_bg": "#aaaaff",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Sunsensor Box"
+        },
+        {
+            "PObject": {
+                "_id": "338000295"
+            },
+            "_bg": "#ffffff",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "steppers status"
+        },
+        {
+            "PObject": {
+                "_id": "956360347"
+            },
+            "_bg": "#ffaaaa",
+            "_bold": true,
+            "_fg": "#000055",
+            "_italic": false,
+            "_linked": true,
+            "_name": "xhigh"
+        },
+        {
+            "PObject": {
+                "_id": "1913941534"
+            },
+            "_bg": "#ffffff",
+            "_bold": true,
+            "_fg": "#ff0000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "high"
+        },
+        {
+            "PObject": {
+                "_id": "2017040817"
+            },
+            "_bg": "#ffffff",
+            "_bold": false,
+            "_fg": "#00aa00",
+            "_italic": false,
+            "_linked": true,
+            "_name": "low"
+        },
+        {
+            "PObject": {
+                "_id": "949614266"
+            },
+            "_bg": "#00ff00",
+            "_bold": true,
+            "_fg": "#000033",
+            "_italic": false,
+            "_linked": true,
+            "_name": "xlow"
+        },
+        {
+            "PObject": {
+                "_id": "2059868534"
+            },
+            "_bg": "#ffff00",
+            "_bold": false,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "shutter"
+        },
+        {
+            "PObject": {
+                "_id": "515713862"
+            },
+            "_bg": "#ffffff",
+            "_bold": false,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Veto"
+        },
+        {
+            "PObject": {
+                "_id": "272768464"
+            },
+            "_bg": "#00ffb3",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Labjack box"
+        },
+        {
+            "PObject": {
+                "_id": "1740116402"
+            },
+            "_bg": "#00ff00",
+            "_bold": false,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "Low Good"
+        },
+        {
+            "PObject": {
+                "_id": "1165535148"
+            },
+            "_bg": "#00ff00",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_GOOD"
+        },
+        {
+            "PObject": {
+                "_id": "1196047623"
+            },
+            "_bg": "#ff0000",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_BAD"
+        },
+        {
+            "PObject": {
+                "_id": "63343233"
+            },
+            "_bg": "#fee1c4",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_RW"
+        },
+        {
+            "PObject": {
+                "_id": "1771970462"
+            },
+            "_bg": "#cdefff",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_PIV"
+        },
+        {
+            "PObject": {
+                "_id": "512511192"
+            },
+            "_bg": "#feffaa",
+            "_bold": true,
+            "_fg": "#0000ff",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_EL"
+        },
+        {
+            "PObject": {
+                "_id": "527972465"
+            },
+            "_bg": "#ffaa00",
+            "_bold": true,
+            "_fg": "#000000",
+            "_italic": false,
+            "_linked": true,
+            "_name": "TIM_WARN"
+        }
+    ],
+    "webPort": "\u0000",
+    "windowCellHeight": 92,
+    "windowCellWidth": 150,
+    "windowHeight": 1386,
+    "windowWidth": 2256
+}

--- a/owl/owl-files/tim/tim2024.owl
+++ b/owl/owl-files/tim/tim2024.owl
@@ -6,349 +6,14 @@
     "boxes": [
         {
             "PObject": {
-                "_id": "391793455"
-            },
-            "_boxTitle": "Cryo Status",
-            "_style": "(P2072147126)",
-            "cellHeight": 23,
-            "cellWidth": 16,
-            "cellX": 3,
-            "cellY": 0,
-            "dataItems": [
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "1044646091"
-                        },
-                        "_map": {
-                            "0": "Intermediate[style=No style (P1911761389)]",
-                            "1": "OPEN[style=Important (P564751211)]",
-                            "2": "CLOSED[style=Important Green (P1055304642)]",
-                            "3": "LOOSE CLOSED[style=No style (P1911761389)]"
-                        }
-                    },
-                    "PObject": {
-                        "_id": "43466910"
-                    },
-                    "_caption": "Pot valve ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_POTVALVE",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "423137424"
-                        },
-                        "_map": {
-                            "11": "OPEN[style=Important (P564751211)]",
-                            "3": "Intermediate",
-                            "7": "CLOSED[style=Important Green (P1055304642)]"
-                        }
-                    },
-                    "PObject": {
-                        "_id": "2030093021"
-                    },
-                    "_caption": "Vent Valve A         ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "LIMS_VENT_A_VALVE",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "1652782798"
-                        },
-                        "_map": {
-                            "11": "OPEN[style=Important (P564751211)]",
-                            "3": "Intermediate[style=No style (P1988869472)]",
-                            "7": "CLOSED[style=Important Green (P1055304642)]"
-                        }
-                    },
-                    "PObject": {
-                        "_id": "1441352504"
-                    },
-                    "_caption": "Vent Valve B",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "LIMS_VENT_B_VALVE",
-                    "type": "PMDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "1132560810"
-                    },
-                    "_caption": "VCS1 HX",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_vcs1_hx",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "1639144508"
-                    },
-                    "_caption": "VCS2 HX",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_vcs2_hx",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "121931520"
-                    },
-                    "_caption": "3He Char   ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_charcoal",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "890339389"
-                    },
-                    "_caption": "M3",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_m3",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "410428068"
-                    },
-                    "_caption": "VCS1 Plate ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_vcs1_plate",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "593607558"
-                    },
-                    "_caption": "VCS2 Plate ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_vcs2_plate",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "2085562844"
-                    },
-                    "_caption": "3He Char HS ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_charcoal_hs",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "607263298"
-                    },
-                    "_caption": "HWP Mount ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_m4",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "551240834"
-                    },
-                    "_caption": "VCS1 Filt",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_vcs1_filt",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "941499730"
-                    },
-                    "_caption": "VCS2 Filt",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_vcs2_filt",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "1432908282"
-                    },
-                    "_caption": "N2 Blowoff",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Nitrogen_Flow",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "206488280"
-                    },
-                    "_caption": "Dichroic Ring ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_hwp",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "1599955911"
-                    },
-                    "_caption": "4K Plate",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_4k_plate",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "914857509"
-                    },
-                    "_caption": "Pot purge flow",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "He_Pot_Purge",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "1225541991"
-                    },
-                    "_caption": "OB Filt",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_ob_filter",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "1529869540"
-                    },
-                    "_caption": "4K Filt",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_4k_filt",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "1471974930"
-                    },
-                    "_caption": "Pump Pot",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_1k_fridge",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "845424335"
-                    },
-                    "_caption": "350 FPA",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "Td_250fpa",
-                    "type": "PNDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "1239853820"
-                        },
-                        "_map": {
-                            "0": "OFF[style=Important (P564751211)]",
-                            "1": "ON[style=Important Green (P1055304642)]"
-                        }
-                    },
-                    "PObject": {
-                        "_id": "1484570975"
-                    },
-                    "_caption": "Heat Switch",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATUS_CHARCOAL_HS",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "426870972"
-                        },
-                        "_map": {
-                            "0": "disallow[style=No style (P1810709534)]",
-                            "1": "standby[style=No style (P1810709534)]",
-                            "2": "warming[style=No style (P1810709534)]",
-                            "3": "burning off[style=No style (P1810709534)]",
-                            "4": "cooling[style=No style (P1810709534)]"
-                        }
-                    },
-                    "PObject": {
-                        "_id": "384152564"
-                    },
-                    "_caption": "Cycle status",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "CYCLE_STATE",
-                    "type": "PMDI"
-                }
-            ],
-            "geometryHeight": 391,
-            "geometryWidth": 272,
-            "geometryX": 51,
-            "geometryY": 0
-        },
-        {
-            "PObject": {
                 "_id": "739666076"
             },
             "_boxTitle": "IF Temperatures",
             "_style": "(P2146903282)",
             "cellHeight": 11,
-            "cellWidth": 16,
-            "cellX": 3,
-            "cellY": 23,
+            "cellWidth": 15,
+            "cellX": 15,
+            "cellY": 3,
             "dataItems": [
                 {
                     "PObject": {
@@ -481,10 +146,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 187,
-            "geometryWidth": 272,
-            "geometryX": 51,
-            "geometryY": 391
+            "geometryHeight": 165,
+            "geometryWidth": 225,
+            "geometryX": 225,
+            "geometryY": 45
         },
         {
             "PObject": {
@@ -492,9 +157,9 @@
             },
             "_boxTitle": "Flight Computers",
             "_style": "(P695404123)",
-            "cellHeight": 13,
+            "cellHeight": 14,
             "cellWidth": 15,
-            "cellX": 19,
+            "cellX": 0,
             "cellY": 0,
             "dataItems": [
                 {
@@ -649,9 +314,9 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 221,
-            "geometryWidth": 255,
-            "geometryX": 323,
+            "geometryHeight": 211,
+            "geometryWidth": 226,
+            "geometryX": 0,
             "geometryY": 0
         },
         {
@@ -660,10 +325,10 @@
             },
             "_boxTitle": "Pointing",
             "_style": "(P1145347128)",
-            "cellHeight": 24,
-            "cellWidth": 17,
-            "cellX": 34,
-            "cellY": 0,
+            "cellHeight": 25,
+            "cellWidth": 16,
+            "cellX": 89,
+            "cellY": 3,
             "dataItems": [
                 {
                     "PMDI": {
@@ -1004,240 +669,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 408,
-            "geometryWidth": 289,
-            "geometryX": 578,
-            "geometryY": 0
-        },
-        {
-            "PObject": {
-                "_id": "2006563740"
-            },
-            "_boxTitle": "ROACHES",
-            "_style": "(P604285081)",
-            "cellHeight": 23,
-            "cellWidth": 17,
-            "cellX": 51,
-            "cellY": 0,
-            "dataItems": [
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "1625456133"
-                        },
-                        "_map": {
-                            "0": "Idle[style=No style (P680910645)]",
-                            "1": "running[style=No style (P680910645)]"
-                        }
-                    },
-                    "PObject": {
-                        "_id": "1087645255"
-                    },
-                    "_caption": "Roach 1  ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_ROACH1",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "1492932784"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "1134360187"
-                    },
-                    "_caption": "Roach 2  ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_ROACH2",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "770047200"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "1254512854"
-                    },
-                    "_caption": "Roach 3 ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_ROACH3",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "1502373517"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "1459603409"
-                    },
-                    "_caption": "Roach 4",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_ROACH4",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "448259194"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "249970160"
-                    },
-                    "_caption": "Roach 5",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_ROACH5",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "1695179163"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "635122636"
-                    },
-                    "_caption": "Pi 1 ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_PI_ROACH1",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "249897208"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "2110035985"
-                    },
-                    "_caption": "Pi 2",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_PI_ROACH2",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "81700900"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "1426782565"
-                    },
-                    "_caption": "Pi 3",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_PI_ROACH3",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "535849677"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "928091075"
-                    },
-                    "_caption": "Pi 4",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_PI_ROACH4",
-                    "type": "PMDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "1990264574"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "595792268"
-                    },
-                    "_caption": "Pi 5",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "STATE_PI_ROACH5",
-                    "type": "PMDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "2043191694"
-                    },
-                    "_caption": "Roach TLM Mode ",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "ROACH_TLM_MODE",
-                    "type": "PNDI"
-                },
-                {
-                    "PObject": {
-                        "_id": "1181107951"
-                    },
-                    "_caption": "gyro",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_extrema": false,
-                    "_format": "",
-                    "_source": "GYR",
-                    "type": "PNDI"
-                },
-                {
-                    "PMDI": {
-                        "PObject": {
-                            "_id": "194574713"
-                        },
-                        "_map": {
-                        }
-                    },
-                    "PObject": {
-                        "_id": "988216910"
-                    },
-                    "_caption": "Multi",
-                    "_captionStyle": "noStyle",
-                    "_defaultStyle": "noStyle",
-                    "_source": "",
-                    "type": "PMDI"
-                }
-            ],
-            "geometryHeight": 391,
-            "geometryWidth": 289,
-            "geometryX": 867,
-            "geometryY": 0
+            "geometryHeight": 376,
+            "geometryWidth": 240,
+            "geometryX": 1335,
+            "geometryY": 45
         },
         {
             "PObject": {
@@ -1245,10 +680,10 @@
             },
             "_boxTitle": "Sun Sensors",
             "_style": "(P2072147126)",
-            "cellHeight": 14,
-            "cellWidth": 17,
-            "cellX": 51,
-            "cellY": 23,
+            "cellHeight": 15,
+            "cellWidth": 16,
+            "cellX": 45,
+            "cellY": 11,
             "dataItems": [
                 {
                     "PMDI": {
@@ -1421,10 +856,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 238,
-            "geometryWidth": 289,
-            "geometryX": 867,
-            "geometryY": 391
+            "geometryHeight": 226,
+            "geometryWidth": 241,
+            "geometryX": 675,
+            "geometryY": 165
         },
         {
             "PObject": {
@@ -1433,9 +868,9 @@
             "_boxTitle": "Pointing Temperatures",
             "_style": "(P2072147126)",
             "cellHeight": 10,
-            "cellWidth": 16,
-            "cellX": 3,
-            "cellY": 34,
+            "cellWidth": 15,
+            "cellX": 15,
+            "cellY": 31,
             "dataItems": [
                 {
                     "PObject": {
@@ -1566,10 +1001,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 170,
-            "geometryWidth": 272,
-            "geometryX": 51,
-            "geometryY": 578
+            "geometryHeight": 150,
+            "geometryWidth": 225,
+            "geometryX": 225,
+            "geometryY": 465
         },
         {
             "PObject": {
@@ -1579,8 +1014,8 @@
             "_style": "(P2072147126)",
             "cellHeight": 16,
             "cellWidth": 15,
-            "cellX": 19,
-            "cellY": 18,
+            "cellX": 30,
+            "cellY": 3,
             "dataItems": [
                 {
                     "PObject": {
@@ -1771,10 +1206,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 272,
-            "geometryWidth": 255,
-            "geometryX": 323,
-            "geometryY": 306
+            "geometryHeight": 240,
+            "geometryWidth": 225,
+            "geometryX": 450,
+            "geometryY": 45
         },
         {
             "PObject": {
@@ -1784,8 +1219,8 @@
             "_style": "(P2072147126)",
             "cellHeight": 12,
             "cellWidth": 15,
-            "cellX": 19,
-            "cellY": 34,
+            "cellX": 30,
+            "cellY": 28,
             "dataItems": [
                 {
                     "PObject": {
@@ -1930,10 +1365,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 204,
-            "geometryWidth": 255,
-            "geometryX": 323,
-            "geometryY": 578
+            "geometryHeight": 180,
+            "geometryWidth": 225,
+            "geometryX": 450,
+            "geometryY": 420
         },
         {
             "PObject": {
@@ -1942,9 +1377,9 @@
             "_boxTitle": "Power Temperatures",
             "_style": "(P2072147126)",
             "cellHeight": 9,
-            "cellWidth": 16,
-            "cellX": 3,
-            "cellY": 45,
+            "cellWidth": 15,
+            "cellX": 15,
+            "cellY": 22,
             "dataItems": [
                 {
                     "PObject": {
@@ -2047,10 +1482,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 153,
-            "geometryWidth": 272,
-            "geometryX": 51,
-            "geometryY": 765
+            "geometryHeight": 135,
+            "geometryWidth": 225,
+            "geometryX": 225,
+            "geometryY": 330
         },
         {
             "PObject": {
@@ -2060,8 +1495,8 @@
             "_style": "(P2072147126)",
             "cellHeight": 8,
             "cellWidth": 15,
-            "cellX": 19,
-            "cellY": 46,
+            "cellX": 15,
+            "cellY": 14,
             "dataItems": [
                 {
                     "PObject": {
@@ -2155,10 +1590,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 136,
-            "geometryWidth": 255,
-            "geometryX": 323,
-            "geometryY": 782
+            "geometryHeight": 120,
+            "geometryWidth": 225,
+            "geometryX": 225,
+            "geometryY": 210
         },
         {
             "PObject": {
@@ -2166,10 +1601,10 @@
             },
             "_boxTitle": "Pointing Sensors OK?",
             "_style": "(P2072147126)",
-            "cellHeight": 13,
-            "cellWidth": 17,
-            "cellX": 34,
-            "cellY": 24,
+            "cellHeight": 8,
+            "cellWidth": 16,
+            "cellX": 45,
+            "cellY": 3,
             "dataItems": [
                 {
                     "PMDI": {
@@ -2286,10 +1721,10 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 221,
-            "geometryWidth": 289,
-            "geometryX": 578,
-            "geometryY": 408
+            "geometryHeight": 121,
+            "geometryWidth": 241,
+            "geometryX": 675,
+            "geometryY": 45
         },
         {
             "PObject": {
@@ -2297,10 +1732,10 @@
             },
             "_boxTitle": "Pointing Vetos",
             "_style": "(P2072147126)",
-            "cellHeight": 13,
-            "cellWidth": 17,
-            "cellX": 34,
-            "cellY": 37,
+            "cellHeight": 11,
+            "cellWidth": 14,
+            "cellX": 61,
+            "cellY": 3,
             "dataItems": [
                 {
                     "PMDI": {
@@ -2469,10 +1904,10 @@
                     "type": "PBDI"
                 }
             ],
-            "geometryHeight": 221,
-            "geometryWidth": 289,
-            "geometryX": 578,
-            "geometryY": 629
+            "geometryHeight": 166,
+            "geometryWidth": 211,
+            "geometryX": 915,
+            "geometryY": 45
         },
         {
             "PObject": {
@@ -2480,10 +1915,10 @@
             },
             "_boxTitle": "Telemetry",
             "_style": "(P2146903282)",
-            "cellHeight": 13,
-            "cellWidth": 22,
-            "cellX": 51,
-            "cellY": 37,
+            "cellHeight": 6,
+            "cellWidth": 30,
+            "cellX": 0,
+            "cellY": 42,
             "dataItems": [
                 {
                     "PObject": {
@@ -2532,10 +1967,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 221,
-            "geometryWidth": 374,
-            "geometryX": 867,
-            "geometryY": 629
+            "geometryHeight": 91,
+            "geometryWidth": 451,
+            "geometryX": 0,
+            "geometryY": 630
         },
         {
             "PObject": {
@@ -2543,10 +1978,10 @@
             },
             "_boxTitle": "Stepper INITs",
             "_style": "(P2072147126)",
-            "cellHeight": 11,
-            "cellWidth": 15,
-            "cellX": 68,
-            "cellY": 0,
+            "cellHeight": 12,
+            "cellWidth": 14,
+            "cellX": 75,
+            "cellY": 3,
             "dataItems": [
                 {
                     "PMDI": {
@@ -2739,10 +2174,10 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 187,
-            "geometryWidth": 255,
-            "geometryX": 1156,
-            "geometryY": 0
+            "geometryHeight": 181,
+            "geometryWidth": 211,
+            "geometryX": 1125,
+            "geometryY": 45
         },
         {
             "PObject": {
@@ -2750,10 +2185,10 @@
             },
             "_boxTitle": "Balance System",
             "_style": "(P150990864)",
-            "cellHeight": 7,
-            "cellWidth": 15,
-            "cellX": 68,
-            "cellY": 11,
+            "cellHeight": 8,
+            "cellWidth": 14,
+            "cellX": 75,
+            "cellY": 15,
             "dataItems": [
                 {
                     "PMDI": {
@@ -2859,10 +2294,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 119,
-            "geometryWidth": 255,
-            "geometryX": 1156,
-            "geometryY": 187
+            "geometryHeight": 121,
+            "geometryWidth": 211,
+            "geometryX": 1125,
+            "geometryY": 225
         },
         {
             "PObject": {
@@ -2870,10 +2305,10 @@
             },
             "_boxTitle": "Charge Controllers",
             "_style": "(P2072147126)",
-            "cellHeight": 5,
-            "cellWidth": 15,
-            "cellX": 68,
-            "cellY": 18,
+            "cellHeight": 6,
+            "cellWidth": 14,
+            "cellX": 61,
+            "cellY": 14,
             "dataItems": [
                 {
                     "PMDI": {
@@ -2942,10 +2377,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 85,
-            "geometryWidth": 255,
-            "geometryX": 1156,
-            "geometryY": 306
+            "geometryHeight": 90,
+            "geometryWidth": 210,
+            "geometryX": 915,
+            "geometryY": 210
         },
         {
             "PObject": {
@@ -2954,9 +2389,9 @@
             "_boxTitle": "",
             "_style": "(P2146903282)",
             "cellHeight": 3,
-            "cellWidth": 22,
-            "cellX": 51,
-            "cellY": 43,
+            "cellWidth": 18,
+            "cellX": 10,
+            "cellY": 45,
             "dataItems": [
                 {
                     "PObject": {
@@ -2983,10 +2418,10 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 51,
-            "geometryWidth": 374,
-            "geometryX": 867,
-            "geometryY": 731
+            "geometryHeight": 45,
+            "geometryWidth": 271,
+            "geometryX": 150,
+            "geometryY": 675
         },
         {
             "PObject": {
@@ -2995,9 +2430,9 @@
             "_boxTitle": "Labjacks",
             "_style": "(P272768464)",
             "cellHeight": 14,
-            "cellWidth": 15,
-            "cellX": 68,
-            "cellY": 23,
+            "cellWidth": 16,
+            "cellX": 45,
+            "cellY": 26,
             "dataItems": [
                 {
                     "PMDI": {
@@ -3152,10 +2587,10 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 238,
-            "geometryWidth": 255,
-            "geometryX": 1156,
-            "geometryY": 391
+            "geometryHeight": 211,
+            "geometryWidth": 241,
+            "geometryX": 675,
+            "geometryY": 390
         },
         {
             "PObject": {
@@ -3163,10 +2598,10 @@
             },
             "_boxTitle": "Bonus Thermistors!",
             "_style": "(P2072147126)",
-            "cellHeight": 13,
-            "cellWidth": 13,
-            "cellX": 73,
-            "cellY": 37,
+            "cellHeight": 9,
+            "cellWidth": 15,
+            "cellX": 30,
+            "cellY": 19,
             "dataItems": [
                 {
                     "PObject": {
@@ -3265,10 +2700,150 @@
                     "type": "PNDI"
                 }
             ],
-            "geometryHeight": 221,
-            "geometryWidth": 221,
-            "geometryX": 1241,
-            "geometryY": 629
+            "geometryHeight": 136,
+            "geometryWidth": 226,
+            "geometryX": 450,
+            "geometryY": 285
+        },
+        {
+            "PObject": {
+                "_id": "1887132079"
+            },
+            "_boxTitle": "Temperatures",
+            "_style": "(P2146903282)",
+            "cellHeight": 3,
+            "cellWidth": 30,
+            "cellX": 15,
+            "cellY": 0,
+            "dataItems": [
+            ],
+            "geometryHeight": 45,
+            "geometryWidth": 451,
+            "geometryX": 225,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "1791246963"
+            },
+            "_boxTitle": "Sensors",
+            "_style": "(P2072147126)",
+            "cellHeight": 3,
+            "cellWidth": 30,
+            "cellX": 45,
+            "cellY": 0,
+            "dataItems": [
+            ],
+            "geometryHeight": 45,
+            "geometryWidth": 450,
+            "geometryX": 675,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "1148071812"
+            },
+            "_boxTitle": "Actuators",
+            "_style": "(P2072147126)",
+            "cellHeight": 3,
+            "cellWidth": 30,
+            "cellX": 75,
+            "cellY": 0,
+            "dataItems": [
+            ],
+            "geometryHeight": 45,
+            "geometryWidth": 451,
+            "geometryX": 1125,
+            "geometryY": 0
+        },
+        {
+            "PObject": {
+                "_id": "611442570"
+            },
+            "_boxTitle": "MCP Core",
+            "_style": "(P695404123)",
+            "cellHeight": 15,
+            "cellWidth": 15,
+            "cellX": 0,
+            "cellY": 14,
+            "dataItems": [
+                {
+                    "PObject": {
+                        "_id": "2076535749"
+                    },
+                    "_caption": "MCP_1HZ_FRAMECOUNT ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MCP_1HZ_FRAMECOUNT",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "510432607"
+                    },
+                    "_caption": "MCP_5HZ_FRAMECOUNT",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MCP_5HZ_FRAMECOUNT",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1012490466"
+                    },
+                    "_caption": "MCP_100HZ_FRAMECOUNT ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MCP_100HZ_FRAMECOUNT",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1494445860"
+                    },
+                    "_caption": "MCP_200HZ_FRAMECOUNT ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MCP_200HZ_FRAMECOUNT",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "125438036"
+                    },
+                    "_caption": "MCP_244HZ_FRAMECOUNT ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MCP_244HZ_FRAMECOUNT",
+                    "type": "PNDI"
+                },
+                {
+                    "PObject": {
+                        "_id": "1263034863"
+                    },
+                    "_caption": "MCP_488HZ_FRAMECOUNT ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_extrema": false,
+                    "_format": "",
+                    "_source": "MCP_488HZ_FRAMECOUNT",
+                    "type": "PNDI"
+                }
+            ],
+            "geometryHeight": 226,
+            "geometryWidth": 226,
+            "geometryX": 0,
+            "geometryY": 210
         }
     ],
     "extremas": [
@@ -3568,12 +3143,12 @@
             },
             "cellHeight": 7,
             "cellWidth": 5,
-            "cellX": 19,
-            "cellY": 12,
-            "geometryHeight": 119,
-            "geometryWidth": 85,
-            "geometryX": 323,
-            "geometryY": 204
+            "cellX": 3,
+            "cellY": 27,
+            "geometryHeight": 105,
+            "geometryWidth": 75,
+            "geometryX": 45,
+            "geometryY": 405
         }
     ],
     "styles": [
@@ -3788,8 +3363,8 @@
         }
     ],
     "webPort": "\u0000",
-    "windowCellHeight": 60,
-    "windowCellWidth": 109,
-    "windowHeight": 1025,
-    "windowWidth": 1853
+    "windowCellHeight": 92,
+    "windowCellWidth": 150,
+    "windowHeight": 1386,
+    "windowWidth": 2256
 }


### PR DESCRIPTION
Begin work on owl files for TIM testing and flight.

Includes a fix to allow inclinometer status to be updated so it can be displayed in telemetry.

![image](https://github.com/tim-balloon/TIMflight/assets/17206559/e8be3cc4-8b4c-46db-8f61-622cc179f48b)

Data shown is from an older April 9 dirfile when I was doing el scans, showing what things look like when two motor controllers are disconnected.