### PR TITLE
Add motor latched fault fields, make el, az default off for ground testing

### DIFF
--- a/blast_config/derived.c
+++ b/blast_config/derived.c
@@ -262,7 +262,7 @@ derived_tng_t derived_list[] = {
     BITWORD("LATCHED_SAFETY_CIRC_EL", "latched_fault_el", 14, 1),
     BITWORD("LATCHED_CONT_CURRENT_EL", "latched_fault_el", 15, 1),
     BITWORD("LATCHED_MOTOR_WIRING_DISCON_EL", "latched_fault_el", 16, 1),
-    BITWORD("LATCHED_SAFE_TORQUE_OFF_ACTIVE_EL", "latched_fault_el", 18, 1),
+    BITWORD("LATCHED_STO_ACTIVE_EL", "latched_fault_el", 18, 1),
 
     BITWORD("LATCHED_DATA_CRC_PIV", "latched_fault_piv", 0, 1),
     BITWORD("LATCHED_AMP_INT_PIV", "latched_fault_piv", 1, 1),
@@ -281,7 +281,7 @@ derived_tng_t derived_list[] = {
     BITWORD("LATCHED_SAFETY_CIRC_PIV", "latched_fault_piv", 14, 1),
     BITWORD("LATCHED_CONT_CURRENT_PIV", "latched_fault_piv", 15, 1),
     BITWORD("LATCHED_MOTOR_WIRING_DISCON_PIV", "latched_fault_piv", 16, 1),
-    BITWORD("LATCHED_SAFE_TORQUE_OFF_ACTIVE_PIV", "latched_fault_piv", 18, 1),
+    BITWORD("LATCHED_STO_ACTIVE_PIV", "latched_fault_piv", 18, 1),
 
     BITWORD("LATCHED_DATA_CRC_RW", "latched_fault_rw", 0, 1),
     BITWORD("LATCHED_AMP_INT_RW", "latched_fault_rw", 1, 1),
@@ -300,7 +300,7 @@ derived_tng_t derived_list[] = {
     BITWORD("LATCHED_SAFETY_CIRC_RW", "latched_fault_rw", 14, 1),
     BITWORD("LATCHED_CONT_CURRENT_RW", "latched_fault_rw", 15, 1),
     BITWORD("LATCHED_MOTOR_WIRING_DISCON_RW", "latched_fault_rw", 16, 1),
-    BITWORD("LATCHED_SAFE_TORQUE_OFF_ACTIVE_RW", "latched_fault_rw", 18, 1),
+    BITWORD("LATCHED_STO_ACTIVE_RW", "latched_fault_rw", 18, 1),
 
     BITWORD("ST_SHORT_CIRC_EL", "status_el", 0, 1),
     BITWORD("ST_AMP_OVER_T_EL", "status_el", 1, 1),

--- a/blast_config/derived.c
+++ b/blast_config/derived.c
@@ -261,6 +261,8 @@ derived_tng_t derived_list[] = {
     BITWORD("LATCHED_FPGA_FAIL2_EL", "latched_fault_el", 13, 1),
     BITWORD("LATCHED_SAFETY_CIRC_EL", "latched_fault_el", 14, 1),
     BITWORD("LATCHED_CONT_CURRENT_EL", "latched_fault_el", 15, 1),
+    BITWORD("LATCHED_MOTOR_WIRING_DISCON_EL", "latched_fault_el", 16, 1),
+    BITWORD("LATCHED_SAFE_TORQUE_OFF_ACTIVE_EL", "latched_fault_el", 18, 1),
 
     BITWORD("LATCHED_DATA_CRC_PIV", "latched_fault_piv", 0, 1),
     BITWORD("LATCHED_AMP_INT_PIV", "latched_fault_piv", 1, 1),
@@ -278,6 +280,8 @@ derived_tng_t derived_list[] = {
     BITWORD("LATCHED_FPGA_FAIL2_PIV", "latched_fault_piv", 13, 1),
     BITWORD("LATCHED_SAFETY_CIRC_PIV", "latched_fault_piv", 14, 1),
     BITWORD("LATCHED_CONT_CURRENT_PIV", "latched_fault_piv", 15, 1),
+    BITWORD("LATCHED_MOTOR_WIRING_DISCON_PIV", "latched_fault_piv", 16, 1),
+    BITWORD("LATCHED_SAFE_TORQUE_OFF_ACTIVE_PIV", "latched_fault_piv", 18, 1),
 
     BITWORD("LATCHED_DATA_CRC_RW", "latched_fault_rw", 0, 1),
     BITWORD("LATCHED_AMP_INT_RW", "latched_fault_rw", 1, 1),
@@ -295,6 +299,8 @@ derived_tng_t derived_list[] = {
     BITWORD("LATCHED_FPGA_FAIL2_RW", "latched_fault_rw", 13, 1),
     BITWORD("LATCHED_SAFETY_CIRC_RW", "latched_fault_rw", 14, 1),
     BITWORD("LATCHED_CONT_CURRENT_RW", "latched_fault_rw", 15, 1),
+    BITWORD("LATCHED_MOTOR_WIRING_DISCON_RW", "latched_fault_rw", 16, 1),
+    BITWORD("LATCHED_SAFE_TORQUE_OFF_ACTIVE_RW", "latched_fault_rw", 18, 1),
 
     BITWORD("ST_SHORT_CIRC_EL", "status_el", 0, 1),
     BITWORD("ST_AMP_OVER_T_EL", "status_el", 1, 1),

--- a/mcp/commanding/commands.c
+++ b/mcp/commanding/commands.c
@@ -2665,7 +2665,7 @@ void InitCommandData()
     CommandData.ec_devices.rw_commutate_next_ec_reset = 0;
     // /TODO: Re-enable El prior to flight
     CommandData.disable_az = 1;
-    CommandData.disable_el = 0;
+    CommandData.disable_el = 1;
 
     CommandData.verbose_rw = 0;
     CommandData.verbose_el = 0;

--- a/owl/owl-files/tim/motor_controller_status.owl
+++ b/owl/owl-files/tim/motor_controller_status.owl
@@ -273,7 +273,7 @@
             },
             "_boxTitle": "EL Latched Faults (0x2183)",
             "_style": "(P512511192)",
-            "cellHeight": 18,
+            "cellHeight": 20,
             "cellWidth": 16,
             "cellX": 20,
             "cellY": 0,
@@ -581,10 +581,48 @@
                     "_defaultStyle": "noStyle",
                     "_source": "LATCHED_CONT_CURRENT_EL",
                     "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "859357952"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1100118808"
+                    },
+                    "_caption": "LATCHED_MOTOR_WIRING_DISCON_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_MOTOR_WIRING_DISCON_EL",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "750528671"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1273575540"
+                    },
+                    "_caption": "LATCHED_STO_ACTIVE_EL ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_STO_ACTIVE_EL",
+                    "type": "PMDI"
                 }
             ],
-            "geometryHeight": 270,
-            "geometryWidth": 240,
+            "geometryHeight": 301,
+            "geometryWidth": 241,
             "geometryX": 300,
             "geometryY": 0
         },
@@ -594,7 +632,7 @@
             },
             "_boxTitle": "PIV Latched Faults (0x2183)",
             "_style": "(P1771970462)",
-            "cellHeight": 18,
+            "cellHeight": 20,
             "cellWidth": 17,
             "cellX": 36,
             "cellY": 0,
@@ -902,10 +940,48 @@
                     "_defaultStyle": "noStyle",
                     "_source": "LATCHED_CONT_CURRENT_PIV",
                     "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1581677881"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "294054424"
+                    },
+                    "_caption": "LATCHED_MOTOR_WIRING_DISCON_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_MOTOR_WIRING_DISCON_PIV",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "2099192393"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1834375607"
+                    },
+                    "_caption": "LATCHED_STO_ACTIVE_PIV ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_STO_ACTIVE_PIV",
+                    "type": "PMDI"
                 }
             ],
-            "geometryHeight": 270,
-            "geometryWidth": 255,
+            "geometryHeight": 301,
+            "geometryWidth": 256,
             "geometryX": 540,
             "geometryY": 0
         },
@@ -915,7 +991,7 @@
             },
             "_boxTitle": "RW Latched Faults (0x2183)",
             "_style": "(P63343233)",
-            "cellHeight": 18,
+            "cellHeight": 20,
             "cellWidth": 17,
             "cellX": 53,
             "cellY": 0,
@@ -1223,10 +1299,48 @@
                     "_defaultStyle": "noStyle",
                     "_source": "LATCHED_CONT_CURRENT_RW",
                     "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "1123507822"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "1605419784"
+                    },
+                    "_caption": "LATCHED_MOTOR_WIRING_DISCON_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_MOTOR_WIRING_DISCON_RW",
+                    "type": "PMDI"
+                },
+                {
+                    "PMDI": {
+                        "PObject": {
+                            "_id": "102085497"
+                        },
+                        "_map": {
+                            "0": "0[style=TIM_GOOD (P1165535148)]",
+                            "1": "1[style=TIM_BAD (P1196047623)]"
+                        }
+                    },
+                    "PObject": {
+                        "_id": "720352951"
+                    },
+                    "_caption": "LATCHED_STO_ACTIVE_RW ",
+                    "_captionStyle": "noStyle",
+                    "_defaultStyle": "noStyle",
+                    "_source": "LATCHED_STO_ACTIVE_RW",
+                    "type": "PMDI"
                 }
             ],
-            "geometryHeight": 270,
-            "geometryWidth": 255,
+            "geometryHeight": 301,
+            "geometryWidth": 256,
             "geometryX": 795,
             "geometryY": 0
         },
@@ -1239,7 +1353,7 @@
             "cellHeight": 31,
             "cellWidth": 16,
             "cellX": 20,
-            "cellY": 18,
+            "cellY": 20,
             "dataItems": [
                 {
                     "PMDI": {
@@ -1793,10 +1907,10 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 466,
+            "geometryHeight": 465,
             "geometryWidth": 240,
             "geometryX": 300,
-            "geometryY": 270
+            "geometryY": 300
         },
         {
             "PObject": {
@@ -1807,7 +1921,7 @@
             "cellHeight": 31,
             "cellWidth": 17,
             "cellX": 36,
-            "cellY": 18,
+            "cellY": 20,
             "dataItems": [
                 {
                     "PMDI": {
@@ -2364,7 +2478,7 @@
             "geometryHeight": 465,
             "geometryWidth": 255,
             "geometryX": 540,
-            "geometryY": 270
+            "geometryY": 300
         },
         {
             "PObject": {
@@ -2375,7 +2489,7 @@
             "cellHeight": 31,
             "cellWidth": 17,
             "cellX": 53,
-            "cellY": 18,
+            "cellY": 20,
             "dataItems": [
                 {
                     "PMDI": {
@@ -2932,7 +3046,7 @@
             "geometryHeight": 465,
             "geometryWidth": 255,
             "geometryX": 795,
-            "geometryY": 270
+            "geometryY": 300
         },
         {
             "PObject": {
@@ -4829,8 +4943,8 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 136,
-            "geometryWidth": 241,
+            "geometryHeight": 135,
+            "geometryWidth": 240,
             "geometryX": 1545,
             "geometryY": 630
         },
@@ -5259,7 +5373,7 @@
                 }
             ],
             "geometryHeight": 135,
-            "geometryWidth": 241,
+            "geometryWidth": 240,
             "geometryX": 1545,
             "geometryY": 495
         },
@@ -5401,8 +5515,8 @@
                     "type": "PMDI"
                 }
             ],
-            "geometryHeight": 121,
-            "geometryWidth": 241,
+            "geometryHeight": 120,
+            "geometryWidth": 240,
             "geometryX": 1050,
             "geometryY": 630
         },


### PR DESCRIPTION
This PR adds missing fields from the EtherCAT motor controller latched fault register. 

It also sets the default values for `CommandData.disable_az = 1` and `CommandData.disable_el = 1`, so that these axes are disabled on startup _if no `prev_status` file exists._ See issue #97; this is an issue that must be fixed before test flight. Good for safety, maybe not so good for test flight.