### PR TITLE
Fix telemetry bug: az_autogyro, el_autogyro overwriting/packed into w…

### DIFF
--- a/mcp/sensors/acs.c
+++ b/mcp/sensors/acs.c
@@ -1677,9 +1677,6 @@ void store_5hz_acs(void)
     if (PointingData[i_point].t >= CommandData.pointing_mode.t)
         sensor_veto |= (1 << 7);
 
-    sensor_veto |= (CommandData.az_autogyro << 8);
-    sensor_veto |= (CommandData.el_autogyro << 9);
-
     SET_UINT16(vetoSensorAddr, sensor_veto);
     SET_UINT8(MagOKAddr[0], PointingData[i_point].mag_ok[0]);
     SET_UINT8(MagOKAddr[1], PointingData[i_point].mag_ok[1]);


### PR DESCRIPTION
…rong bits of veto_sensor bitfield

Might fix a bug Shubh and I saw when trying to manually adjust gyro bias values - it seemed that when sending new gyro offsets using `az_gyro_offset` command, `az_autogyro` did not go false in telemetry, when it should have, even though we saw the az solution drift rate change according to our command.

Without this fix, the `AZ_AUTO_GYRO` bitfield telemetry variable is the logical OR of `CommanData.az_autogyro` and `CommandData.el_autogyro`, and the `IS_SCHED` telemetry variable is the logical OR of `CommandData.uplink_sched` and `CommandData.az_autogyro`.