### PR TITLE
TIM FTS 2024 Solar Panel Az for "antisun" pointing mode

### DIFF
--- a/mcp/commanding/commands.c
+++ b/mcp/commanding/commands.c
@@ -77,6 +77,8 @@ static const double lock_positions[NUM_LOCK_POS] = {0.0, 22.5, 45.0, 67.5, 90.0}
 #define FTS_LAT 34.490081
 #define FTS_LON 255.778092
 
+#define TIM_SOLAR_PANEL_AZ 180.0 + 31.2 - 17.7 // deg, measured by SA in FTS on 2024-08-23
+
 /*
  * The distance (in ULPS) between two floating-point numbers above which they
  * will be considered different.
@@ -462,7 +464,7 @@ void SingleCommand(enum singleCommand command, int scheduled)
 
         /* POINTING */
         case antisun:  // turn antisolar (az-only)
-            sun_az = PointingData[i_point].sun_az + 250;  // point solar panels to sun
+            sun_az = PointingData[i_point].sun_az + TIM_SOLAR_PANEL_AZ;  // point solar panels to sun
             NormalizeAngle(&sun_az);
             CommandData.pointing_mode.nw = CommandData.slew_veto;
             CommandData.pointing_mode.mode = P_AZEL_GOTO;

--- a/mcp/commanding/commands.c
+++ b/mcp/commanding/commands.c
@@ -78,7 +78,8 @@ static const double lock_positions[NUM_LOCK_POS] = {0.0, 22.5, 45.0, 67.5, 90.0}
 #define FTS_LON 255.778092
 
 #define TIM_SOLAR_PANEL_AZ 180.0 + 31.2 - 17.7 // deg, measured by SA in FTS on 2024-08-23
-
+// 31.2 deg measured as the az offset of the solar panel mounting rod from sunshade connection
+// 17.7 deg measured as the az offset of the sunshade connection from the sunshade itself
 /*
  * The distance (in ULPS) between two floating-point numbers above which they
  * will be considered different.


### PR DESCRIPTION
very small code addition to reflect TIM's FTS solar panel configuration. 
Addresses #4. Do not close the issue (will need to redo this for science flight), but remove the "PREFLIGHT-MUSTFIX" label from it.