### PR TITLE
add ulimit conf

### DIFF
--- a/blast_etc/ulimit/limits.conf.fc
+++ b/blast_etc/ulimit/limits.conf.fc
@@ -1,0 +1,73 @@
+###########################
+# this version:
+# 	changes the maximum number of open file descriptors
+# 	from 1024 to 4096 on the flight computer
+# 	typical usage should not require this limit change, 
+# 	but no downside, esp. when we sometimes run GSE soft
+# 	on FC for testing, etc.
+# Run:
+# 	sudo cp limits.conf.fc /etc/security/limits.conf 
+# Shubh Agrawal for TIM 2025 
+###########################
+
+# /etc/security/limits.conf
+#
+#Each line describes a limit for a user in the form:
+#
+#<domain>        <type>  <item>  <value>
+#
+#Where:
+#<domain> can be:
+#        - a user name
+#        - a group name, with @group syntax
+#        - the wildcard *, for default entry
+#        - the wildcard %, can be also used with %group syntax,
+#                 for maxlogin limit
+#        - NOTE: group and wildcard limits are not applied to root.
+#          To apply a limit to the root user, <domain> must be
+#          the literal username root.
+#
+#<type> can have the two values:
+#        - "soft" for enforcing the soft limits
+#        - "hard" for enforcing hard limits
+#
+#<item> can be one of the following:
+#        - core - limits the core file size (KB)
+#        - data - max data size (KB)
+#        - fsize - maximum filesize (KB)
+#        - memlock - max locked-in-memory address space (KB)
+#        - nofile - max number of open file descriptors
+#        - rss - max resident set size (KB)
+#        - stack - max stack size (KB)
+#        - cpu - max CPU time (MIN)
+#        - nproc - max number of processes
+#        - as - address space limit (KB)
+#        - maxlogins - max number of logins for this user
+#        - maxsyslogins - max number of logins on the system
+#        - priority - the priority to run user process with
+#        - locks - max number of file locks the user can hold
+#        - sigpending - max number of pending signals
+#        - msgqueue - max memory used by POSIX message queues (bytes)
+#        - nice - max nice priority allowed to raise to values: [-20, 19]
+#        - rtprio - max realtime priority
+#        - chroot - change root to directory (Debian-specific)
+#
+#<domain>      <type>  <item>         <value>
+#
+
+#*               soft    core            0
+#root            hard    core            100000
+#*               hard    rss             10000
+#@student        hard    nproc           20
+#@faculty        soft    nproc           20
+#@faculty        hard    nproc           50
+#ftp             hard    nproc           0
+#ftp             -       chroot          /ftp
+#@student        -       maxlogins       4
+
+root	hard	nofile	4096
+root	soft	nofile	4096
+tim	hard	nofile	4096
+tim	soft	nofile	4096	
+
+# End of file

--- a/blast_etc/ulimit/limits.conf.gse
+++ b/blast_etc/ulimit/limits.conf.gse
@@ -1,0 +1,78 @@
+###########################
+# this version:
+#       changes the maximum number of open file descriptors
+#       from 1024 to 4096 on the ground station computer.
+#       Needed to run mole properly, so that we can open enough
+#       file descriptors while saving to dirfiles
+#       typical usage should not require this limit change, 
+#       but no downside, esp. when we sometimes run GSE soft
+#       on FC for testing, etc.
+# Note:
+# 	Change "tim" below to the username of your GSE.
+# Run:
+# 	vi limits.conf.gse (to confirm that the username is correct)
+#       sudo cp limits.conf.gse /etc/security/limits.conf 
+# Shubh Agrawal for TIM 2025 
+###########################
+
+# /etc/security/limits.conf
+#
+#Each line describes a limit for a user in the form:
+#
+#<domain>        <type>  <item>  <value>
+#
+#Where:
+#<domain> can be:
+#        - a user name
+#        - a group name, with @group syntax
+#        - the wildcard *, for default entry
+#        - the wildcard %, can be also used with %group syntax,
+#                 for maxlogin limit
+#        - NOTE: group and wildcard limits are not applied to root.
+#          To apply a limit to the root user, <domain> must be
+#          the literal username root.
+#
+#<type> can have the two values:
+#        - "soft" for enforcing the soft limits
+#        - "hard" for enforcing hard limits
+#
+#<item> can be one of the following:
+#        - core - limits the core file size (KB)
+#        - data - max data size (KB)
+#        - fsize - maximum filesize (KB)
+#        - memlock - max locked-in-memory address space (KB)
+#        - nofile - max number of open file descriptors
+#        - rss - max resident set size (KB)
+#        - stack - max stack size (KB)
+#        - cpu - max CPU time (MIN)
+#        - nproc - max number of processes
+#        - as - address space limit (KB)
+#        - maxlogins - max number of logins for this user
+#        - maxsyslogins - max number of logins on the system
+#        - priority - the priority to run user process with
+#        - locks - max number of file locks the user can hold
+#        - sigpending - max number of pending signals
+#        - msgqueue - max memory used by POSIX message queues (bytes)
+#        - nice - max nice priority allowed to raise to values: [-20, 19]
+#        - rtprio - max realtime priority
+#        - chroot - change root to directory (Debian-specific)
+#
+#<domain>      <type>  <item>         <value>
+#
+
+#*               soft    core            0
+#root            hard    core            100000
+#*               hard    rss             10000
+#@student        hard    nproc           20
+#@faculty        soft    nproc           20
+#@faculty        hard    nproc           50
+#ftp             hard    nproc           0
+#ftp             -       chroot          /ftp
+#@student        -       maxlogins       4
+
+root	hard	nofile	4096
+root	soft	nofile	4096
+tim	hard	nofile	4096
+tim	soft	nofile	4096	
+
+# End of file


### PR DESCRIPTION
Add a template for `limit.conf` files for a GSE and FC. Increases the maximum number of open file descriptors from 1024 to 4096. Effectively `ulimit -n 4096` but persistent.

**Why?**
Working on integrating cryogenic housekeeping, I discovered some strange behavior that I will detail below. But the cause was that our number of individual channels in `tx_struct_tng` was close enough to the marginal limit, such that when you run `mole` on a GSE, it opens too many files while trying to save data to dirfiles. This can manifest in a few different symptoms:

1. You do **not** get data from all channels in your dirfiles, when you know that the telemetry bandwidth is high-enough. This is because `mole` silently failed to open all the file descriptors for all channels in the dirfile.
2. When checking `kst` field names, you do not see any derived channels (nominally in uppercase, such as `AZ, EL, ...`). This happens because, as `mole` attempts to open the `calspecs` file saved by `groundhog`, it cannot as there are already too many files open in the dirfile. So, the `format` file in the dirfile ends up missing all the information about the derived channels, and `kst` does not, thus, show them as options. I checked this by checking the various `calspecs` and `format` files produced/used by each link in the chain from `mcp, groundhog, mole, guaca, kst`. You should be able to see that `.cs.format` file in `/data/rawdir` or `/data/groundhog` contains the derived channels (and `ll.format` has the nominal channels), and the `format` file in the dirfile output from mole is a concantenation of the two.
3. Errors of this kind are tough to reproduce deterministically. If you are just at the `ulimit nofile` limit, behavior might depend on what _other_ files you have open from the shell for that user.

**Usage**
One should only need to put the confile file on a GSE, for ground software to work. I do not, however, see a negative for all changing the setting on the FCs, if only to make things interchangeable for testing.  

`sudo cp limits.conf.fc /etc/security/limits.conf`
`sudo cp limits.conf.gse /etc/security/limits.conf`

One should make sure, however, that the username `tim` in the `.gse` file matches the username of your ground station. I have `tim` there as that is what we  conventionally use.

**Acceptance?**

`ulimit -a` should show number of file description allowed to be 4096, persistently between reboots.

While the code to reproduce the problem is not on `main` yet, if you cloned the `shubh-hk` branch, and tried to compile `mcp`, `groundhog`, and run the entire change of the ground software, you should find derived channels missing from the `kst` field selector, if your `ulimit` is set to the OS default at 1024.
