### PR TITLE
Integrating TauHK: Initial Commanding Structure

### DIFF
--- a/blast_config/command_list.c
+++ b/blast_config/command_list.c
@@ -472,7 +472,7 @@ struct mcom mcommands[plugh + 2] = {
             {"Proportional (P)", 0.0, 1024.0, 'f', "NONE"},
             {"Integral (I)", 0.0, 1024.0, 'f', "NONE"},
             {"Derivative (D)", 0.0, 1024.0, 'f', "NONE"},
-            {"Setpoint (mK)", 0.0, 100.0, 'f', "NONE"}
+            {"Setpoint (mK)", 10.0, 500.0, 'f', "NONE"}
         }
     },
 

--- a/blast_config/command_list.c
+++ b/blast_config/command_list.c
@@ -363,7 +363,7 @@ struct mcom mcommands[plugh + 2] = {
         }
     },
     // PID
-    {COMMAND(set_cryo_pid), "Set 250mK PID parameters", GR_CRYO, 3,
+    {COMMAND(set_cryo_pid), "Set 250mK PID parameters", GR_CRYO, 4,
         {
             {"Proportional (P)", 0.0, 1024.0, 'f', "NONE"},
             {"Integral (I)", 0.0, 1024.0, 'f', "NONE"},

--- a/blast_config/command_list.c
+++ b/blast_config/command_list.c
@@ -134,6 +134,15 @@ struct scom scommands[xyzzy + 1] = {
     {COMMAND(watchdog_off), "Turn off power to hardware watchdog on motor PBOB", GR_POWER},
 
     /* HOUSEKEEPING */
+    // cryo commands
+    {COMMAND(enable_cryo_pid), "Enable cryo PID control", GR_CRYO},
+    {COMMAND(disable_cryo_pid), "Disable cryo PID control", GR_CRYO},
+    {COMMAND(reset_cryo_pid), "Reset cryo PID control (zeroes integral term)", GR_CRYO},
+    {COMMAND(start_fridge_cycle), "Start a fridge cycle", GR_CRYO},
+    {COMMAND(stop_fridge_cycle), "Stop a fridge cycle", GR_CRYO},
+    {COMMAND(enable_fridge_cycle), "Enable Auto-trigger of fridge cycles", GR_CRYO},
+    {COMMAND(disable_fridge_cycle), "Disable Auto-trigger of fridge cycles", GR_CRYO},
+    {COMMAND(skip_to_next_fridge_stage), "Skip to the next stage of the fridge cycle", GR_CRYO},
 
     /* DETECTORS */
 
@@ -302,6 +311,66 @@ struct scom scommands[xyzzy + 1] = {
  */
 struct mcom mcommands[plugh + 2] = {
     /* HOUSEKEEPING */
+    // Diodes
+    {COMMAND(disable_diode), "Disable Diode Channel (1-8) on Card (1-2)", GR_CRYO, 2,
+        {
+            {"Card Number", 1, 2, 'i', "NONE"},
+            {"Diode Channel", 1, 8, 'i', "NONE"}
+        }
+    },
+    {COMMAND(enable_diode_ac), "Enable Diode (1-8) on Card (1-2) in AC mode", GR_CRYO, 2,
+        {
+            {"Card Number", 1, 2, 'i', "NONE"},
+            {"Diode Channel", 1, 8, 'i', "NONE"}
+        }
+    },
+    {COMMAND(enable_diode_dc), "Enable Diode (1-8) on Card (1-2) in DC mode", GR_CRYO, 2,
+        {
+            {"Card Number", 1, 2, 'i', "NONE"},
+            {"Diode Channel", 1, 8, 'i', "NONE"}
+        }
+    },
+    // RTDs
+    {COMMAND(set_rtd_logdac), "Set logdac for RTD (1-8) on Card (1-2)", GR_CRYO, 3,
+        {
+            {"Card Number", 1, 2, 'i', "NONE"},
+            {"RTD Channel", 1, 8, 'i', "NONE"},
+            {"LogDAC Value", 0, 16, 'i', "NONE"}
+        }
+    },
+    {COMMAND(set_rtd_muv), "Set microvolts for RTD (1-8) on Card (1-2)", GR_CRYO, 3,
+        {
+            {"Card Number", 1, 2, 'i', "NONE"},
+            {"RTD Channel", 1, 8, 'i', "NONE"},
+            {"microvolts Value", 0.0, 32.0, 'f', "NONE"}
+        }
+    },
+    // Heaters
+    {COMMAND(enable_heater), "Enable Heater (1-8)", GR_CRYO, 1,
+        {
+            {"Heater Channel", 1, 8, 'i', "NONE"},
+        }
+    },
+    {COMMAND(disable_heater), "Disable Heater (1-8)", GR_CRYO, 1,
+        {
+            {"Heater Channel", 1, 8, 'i', "NONE"},
+        }
+    },
+    {COMMAND(set_heater_v), "Set volts on Heater (1-8)", GR_CRYO, 2,
+        {
+            {"Heater Channel", 1, 8, 'i', "NONE"},
+            {"Volts Value", 0.0, 5.0, 'f', "NONE"}
+        }
+    },
+    // PID
+    {COMMAND(set_cryo_pid), "Set 250mK PID parameters", GR_CRYO, 3,
+        {
+            {"Proportional (P)", 0.0, 1024.0, 'f', "NONE"},
+            {"Integral (I)", 0.0, 1024.0, 'f', "NONE"},
+            {"Derivative (D)", 0.0, 1024.0, 'f', "NONE"},
+            {"Setpoint (mK)", 0.0, 100.0, 'f', "NONE"}
+        }
+    },
 
     /* DETECTORS */
 

--- a/blast_config/include/command_list.h
+++ b/blast_config/include/command_list.h
@@ -111,7 +111,13 @@ enum singleCommand {
     pss_on, pss_off,
     incs_on, incs_off,
     watchdog_on, watchdog_off,
+    
     /* HOUSEKEEPING */
+    // cryo commands
+    enable_cryo_pid, disable_cryo_pid, reset_cryo_pid, 
+    start_fridge_cycle, stop_fridge_cycle,
+    enable_fridge_cycle, disable_fridge_cycle,
+    skip_to_next_fridge_stage,
 
     /* DETECTORS */
 
@@ -238,6 +244,10 @@ enum singleCommand {
  * order relative to the command definitions in command_list.c */
 enum multiCommand {
     /* HOUSEKEEPING */
+    disable_diode, enable_diode_ac, enable_diode_dc, // Diodes
+    set_rtd_logdac, set_rtd_muv, // RTDs
+    enable_heater, disable_heater, set_heater_v, // heaters
+    set_cryo_pid, // PID
 
     /* DETECTORS */
 

--- a/kst/tim/cryo_hk.kst
+++ b/kst/tim/cryo_hk.kst
@@ -1,0 +1,1499 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kst version="2.0.9">
+    <data>
+        <source reader="Directory of Binary Files" updateType="0" file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" initialXNum="1" initialTNum="1" initialDSNum="1"/>
+    </data>
+    <variables>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="INDEX" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="1" initialXNum="2"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_lna_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="2" initialXNum="15"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_cbob_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="3" initialXNum="28"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_fridge_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="4" initialXNum="41"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_ic_hsw_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="5" initialXNum="54"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_uc_hsw_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="6" initialXNum="67"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_4he_hsw_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="7" initialXNum="80"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_4k_filt_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="8" initialXNum="93"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_hawkeye_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="9" initialXNum="106"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_ic_pump_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="10" initialXNum="119"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_lw_coll_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="11" initialXNum="132"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_uc_pump_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="12" initialXNum="145"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_4he_film_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="13" initialXNum="158"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_4he_pump_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="14" initialXNum="171"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_4k_plate_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="15" initialXNum="184"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_cop_stop_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="16" initialXNum="197"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_vcs1_hex_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="17" initialXNum="210"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_vcs1_top_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="18" initialXNum="223"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_vcs2_hex_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="19" initialXNum="236"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_vcs2_top_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="20" initialXNum="249"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_4k_shield_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="21" initialXNum="262"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_off_relay_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="22" initialXNum="275"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_vcs1_filt_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="23" initialXNum="288"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_vcs2_filt_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="24" initialXNum="301"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="diode_lw_grating_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="25" initialXNum="314"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="INDEX" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="26" initialXNum="327"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_1_1_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="27" initialXNum="340"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_1_2_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="28" initialXNum="353"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_1_3_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="29" initialXNum="366"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_1_4_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="30" initialXNum="379"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_1_5_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="31" initialXNum="392"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_1_6_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="32" initialXNum="405"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_1_7_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="33" initialXNum="418"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_ic_head_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="34" initialXNum="431"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_lw_filt_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="35" initialXNum="444"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_uc_head_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="36" initialXNum="457"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_4he_head_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="37" initialXNum="470"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_lw_fpu_1k_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="38" initialXNum="483"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_lw_250_fin_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="39" initialXNum="496"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_lw_fpu_250_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="40" initialXNum="509"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_lw_fpu_350_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="41" initialXNum="522"/>
+        <datavector file="/data/etc/mole.lnk" fileRelative="../../../../../../data/etc/mole.lnk" field="rtd_lw_fpu_cor_temperature" start="-1" count="100" skip="-1" doAve="false" startUnits="" rangeUnits="" initialVNum="42" initialXNum="535"/>
+    </variables>
+    <objects/>
+    <relations>
+        <curve xvector="INDEX (V1)" yvector="diode\_lna\_temperature (V2)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="0" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="990822208" initialCNum="1"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_cbob\_temperature (V3)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="1" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="2704" initialCNum="2"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_fridge\_temperature (V4)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="2" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="0" initialCNum="3"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_ic\_hsw\_temperature (V5)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="3" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1524562304" initialCNum="4"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_uc\_hsw\_temperature (V6)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="4" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="1051198912" initialCNum="5"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_4he\_hsw\_temperature (V7)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="5" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="14" initialCNum="6"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_4k\_filt\_temperature (V8)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="6" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="984946096" initialCNum="7"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_hawkeye\_temperature (V9)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="7" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="0" initialCNum="8"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_ic\_pump\_temperature (V10)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="8" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="0" initialCNum="9"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_lw\_coll\_temperature (V11)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="9" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="24" initialCNum="10"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_uc\_pump\_temperature (V12)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="10" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="0" initialCNum="11"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_4he\_film\_temperature (V13)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="11" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="0" initialCNum="12"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_4he\_pump\_temperature (V14)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="12" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="986776512" initialCNum="13"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_4k\_plate\_temperature (V15)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="13" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="1036030512" initialCNum="14"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_cop\_stop\_temperature (V16)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="0" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="96" initialCNum="15"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_vcs1\_hex\_temperature (V17)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="1" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="1029576448" initialCNum="16"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_vcs1\_top\_temperature (V18)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="2" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="0" initialCNum="17"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_vcs2\_hex\_temperature (V19)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="3" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="24" initialCNum="18"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_vcs2\_top\_temperature (V20)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="4" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="1036044416" initialCNum="19"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_4k\_shield\_temperature (V21)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="5" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="1036046864" initialCNum="20"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_off\_relay\_temperature (V22)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="6" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="1036049616" initialCNum="21"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_vcs1\_filt\_temperature (V23)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="7" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="96" initialCNum="22"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_vcs2\_filt\_temperature (V24)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="8" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="0" initialCNum="23"/>
+        <curve xvector="INDEX (V1)" yvector="diode\_lw\_grating\_temperature (V25)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="9" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="0" initialCNum="24"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_1\_1\_temperature (V27)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="0" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="1" initialCNum="25"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_1\_2\_temperature (V28)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="1" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="0" initialCNum="26"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_1\_3\_temperature (V29)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="2" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="27"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_1\_4\_temperature (V30)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="3" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="28"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_1\_5\_temperature (V31)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="4" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="29"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_1\_6\_temperature (V32)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="5" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="30"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_1\_7\_temperature (V33)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="6" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="31"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_ic\_head\_temperature (V34)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="7" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="32"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_lw\_filt\_temperature (V35)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="8" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="33"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_uc\_head\_temperature (V36)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="9" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="34"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_4he\_head\_temperature (V37)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="10" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="35"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_lw\_fpu\_1k\_temperature (V38)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="11" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="36"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_lw\_250\_fin\_temperature (V39)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="12" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="37"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_lw\_fpu\_250\_temperature (V40)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="13" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="38"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_lw\_fpu\_350\_temperature (V41)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="0" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="39"/>
+        <curve xvector="INDEX (V26)" yvector="rtd\_lw\_fpu\_cor\_temperature (V42)" color="#d10000" alpha="255" headcolor="#000000" headalpha="255" barfillcolor="#000000" barfillalpha="255" haslines="true" linewidth="0" linestyle="0" haspoints="false" pointtype="1" pointdensity="0" pointsize="12" hasbars="false" ignoreautoscale="false" hashead="false" headtype="-1" initialCNum="40"/>
+    </relations>
+    <graphics currentTab="1">
+        <view name="Diodes" width="2483" height="1253" color="#ffffff" style="0">
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="23" name="Plot">
+                <position x="1241.0002012882449" y="1041.3952641165756" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.6244464573268921" centery="0.9139994795732502" posx="0.4997987117552335" posy="0.8311215196461099" leftx="0.4997987117552335" lefty="0.9968774395003903" rightx="0.7490942028985508" righty="0.9968774395003903" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333171" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="221" height="21"/>
+                    <relativesize width="0.4355880742803734" height="0.14463590116734934" centerx="0.2510416012955318" centery="0.1730979006668694" posx="0.03324756415534512" posy="0.10077995008319468" leftx="0.03324756415534512" lefty="0.24541585125054405" rightx="0.46883563843571857" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_vcs2\_filt\_temperature vs INDEX (C23)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1035832784"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="21" name="Plot">
+                <position x="2.9987922705314007" y="1041.3952641165756" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.12585547504025765" centery="0.9139994795732502" posx="0.0012077294685990338" posy="0.8311215196461099" leftx="0.0012077294685990338" lefty="0.9968774395003903" rightx="0.25050322061191627" righty="0.9968774395003903" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="225" height="21"/>
+                    <relativesize width="0.443472021326172" height="0.14463590116734934" centerx="0.25498357481843115" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.47671958548151716" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_off\_relay\_temperature vs INDEX (C21)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="23.328475952148438" width="99" height="0.0026702880859375"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="19" name="Plot">
+                <position x="1241.0002012882449" y="833.7030965391621" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.6921675774135"/>
+                <relativesize width="0.24929549114331723" height="0.16575591985428054" centerx="0.6244464573268921" centery="0.7482435597189696" posx="0.4997987117552335" posy="0.6653655997918293" leftx="0.4997987117552335" lefty="0.8311215196461099" rightx="0.7490942028985508" righty="0.8311215196461099" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922563" z="500"/>
+                    <rect x="0" y="0" width="224" height="21"/>
+                    <relativesize width="0.4415010345647224" height="0.1446359011673493" centerx="0.2539980814377063" centery="0.1730979006668693" posx="0.03324756415534515" posy="0.10077995008319464" leftx="0.03324756415534515" lefty="0.24541585125054396" rightx="0.4747485987200675" righty="0.24541585125054396" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_vcs2\_top\_temperature vs INDEX (C19)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="24"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="295.49755859375" width="99" height="0.0064697265625"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="17" name="Plot">
+                <position x="2.9987922705314007" y="833.7030965391621" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.6921675774135"/>
+                <relativesize width="0.24929549114331723" height="0.16575591985428054" centerx="0.12585547504025765" centery="0.7482435597189696" posx="0.0012077294685990338" posy="0.6653655997918293" leftx="0.0012077294685990338" lefty="0.8311215196461099" rightx="0.25050322061191627" righty="0.8311215196461099" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922563" z="500"/>
+                    <rect x="0" y="0" width="224" height="21"/>
+                    <relativesize width="0.4415010345647224" height="0.1446359011673493" centerx="0.2539980814377063" centery="0.1730979006668693" posx="0.03324756415534515" posy="0.10077995008319464" leftx="0.03324756415534515" lefty="0.24541585125054396" rightx="0.4747485987200675" righty="0.24541585125054396" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_vcs1\_top\_temperature vs INDEX (C17)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1035303792"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="295.7782897949219" width="99" height="0.0069580078125"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="15" name="Plot">
+                <position x="1241.0002012882449" y="626.0109289617486" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.6921675774135"/>
+                <relativesize width="0.24929549114331723" height="0.16575591985428054" centerx="0.6244464573268921" centery="0.5824876398646891" posx="0.4997987117552335" posy="0.4996096799375488" leftx="0.4997987117552335" lefty="0.6653655997918293" rightx="0.7490942028985508" righty="0.6653655997918293" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922563" z="500"/>
+                    <rect x="0" y="0" width="226" height="21"/>
+                    <relativesize width="0.44544300808762166" height="0.1446359011673493" centerx="0.255969068199156" centery="0.1730979006668693" posx="0.03324756415534515" posy="0.10077995008319464" leftx="0.03324756415534515" lefty="0.24541585125054396" rightx="0.4786905722429668" righty="0.24541585125054396" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_cop\_stop\_temperature vs INDEX (C15)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="24"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="13" name="Plot">
+                <position x="2.9987922705314007" y="626.0109289617486" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.6921675774135"/>
+                <relativesize width="0.24929549114331723" height="0.16575591985428054" centerx="0.12585547504025765" centery="0.5824876398646891" posx="0.0012077294685990338" posy="0.4996096799375488" leftx="0.0012077294685990338" lefty="0.6653655997918293" rightx="0.25050322061191627" righty="0.6653655997918293" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922563" z="500"/>
+                    <rect x="0" y="0" width="234" height="21"/>
+                    <relativesize width="0.4612109021792189" height="0.1446359011673493" centerx="0.2638530152449546" centery="0.1730979006668693" posx="0.03324756415534515" posy="0.10077995008319464" leftx="0.03324756415534515" lefty="0.24541585125054396" rightx="0.49445846633456403" righty="0.24541585125054396" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_4he\_pump\_temperature vs INDEX (C13)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1034950384"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-150.39183959960937" width="99" height="0.19999999999998863"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="11" name="Plot">
+                <position x="1241.0002012882449" y="418.3187613843352" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.6244464573268921" centery="0.4167317200104086" posx="0.4997987117552335" posy="0.3338537600832683" leftx="0.4997987117552335" lefty="0.4996096799375488" rightx="0.7490942028985508" righty="0.4996096799375488" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.13245940092257" z="500"/>
+                    <rect x="0" y="0" width="226" height="21"/>
+                    <relativesize width="0.44544300808762166" height="0.14463590116734934" centerx="0.255969068199156" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319471" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.4786905722429668" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_uc\_pump\_temperature vs INDEX (C11)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1034774048"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-150.39183959960937" width="99" height="0.19999999999998863"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="9" name="Plot">
+                <position x="2.9987922705314007" y="418.3187613843352" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.12585547504025765" centery="0.4167317200104086" posx="0.0012077294685990338" posy="0.3338537600832683" leftx="0.0012077294685990338" lefty="0.4996096799375488" rightx="0.25050322061191627" righty="0.4996096799375488" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.13245940092257" z="500"/>
+                    <rect x="0" y="0" width="222" height="21"/>
+                    <relativesize width="0.43755906104182296" height="0.14463590116734934" centerx="0.25202709467625667" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319471" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.4708066251971682" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_ic\_pump\_temperature vs INDEX (C9)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1034596976"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-150.39183959960937" width="99" height="0.19999999999998863"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="7" name="Plot">
+                <position x="1241.0002012882449" y="210.62659380692168" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.6244464573268921" centery="0.250975800156128" posx="0.4997987117552335" posy="0.16809784022898777" leftx="0.4997987117552335" lefty="0.3338537600832683" rightx="0.7490942028985508" righty="0.3338537600832683" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="211" height="21"/>
+                    <relativesize width="0.4158782066658769" height="0.14463590116734934" centerx="0.24118666748828357" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.449125770821222" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_4k\_filt\_temperature vs INDEX (C7)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1034421264"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="5" name="Plot">
+                <position x="2.9987922705314007" y="210.62659380692168" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.12585547504025765" centery="0.250975800156128" posx="0.0012077294685990338" posy="0.16809784022898777" leftx="0.0012077294685990338" lefty="0.3338537600832683" rightx="0.25050322061191627" righty="0.3338537600832683" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="216" height="21"/>
+                    <relativesize width="0.4257331404731251" height="0.14463590116734934" centerx="0.2461141343919077" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.4589807046284703" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_uc\_hsw\_temperature vs INDEX (C5)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="986776512"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="24"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-150.39183959960937" width="99" height="0.19999999999998863"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="3" name="Plot">
+                <position x="1241.0002012882449" y="2.9344262295081966" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.6244464573268921" centery="0.08521988030184752" posx="0.4997987117552335" posy="0.00234192037470726" leftx="0.4997987117552335" lefty="0.16809784022898777" rightx="0.7490942028985508" righty="0.16809784022898777" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="209" height="21"/>
+                    <relativesize width="0.41193623314297756" height="0.14463590116734934" centerx="0.2392156807268339" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.4451837972983227" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_fridge\_temperature vs INDEX (C3)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1007636784"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="1" name="Plot">
+                <position x="2.9987922705314007" y="2.9344262295081966" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.12585547504025765" centery="0.08521988030184752" posx="0.0012077294685990338" posy="0.00234192037470726" leftx="0.0012077294685990338" lefty="0.16809784022898777" rightx="0.25050322061191627" righty="0.16809784022898777" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="192" height="21"/>
+                    <relativesize width="0.37842945819833346" height="0.14463590116734934" centerx="0.22246229325451186" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.4116770223536786" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_lna\_temperature vs INDEX (C1)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="981122048"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="992926464"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="2" name="Plot">
+                <position x="621.9994967793881" y="2.9344262295081966" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.37515096618357485" centery="0.08521988030184752" posx="0.25050322061191627" posy="0.00234192037470726" leftx="0.25050322061191627" lefty="0.16809784022898777" rightx="0.4997987117552335" righty="0.16809784022898777" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="203" height="21"/>
+                    <relativesize width="0.40011031257427965" height="0.14463590116734934" centerx="0.23330272044248496" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.4333578767296248" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_cbob\_temperature vs INDEX (C2)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="981441616"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="304"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="4" name="Plot">
+                <position x="1860.0009057971015" y="2.9344262295081966" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.8737419484702094" centery="0.08521988030184752" posx="0.7490942028985508" posy="0.00234192037470726" leftx="0.7490942028985508" lefty="0.16809784022898777" rightx="0.998389694041868" righty="0.16809784022898777" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="212" height="21"/>
+                    <relativesize width="0.41784919342732646" height="0.14463590116734934" centerx="0.24217216086900842" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.45109675758267165" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_ic\_hsw\_temperature vs INDEX (C4)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1017023488"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-150.39183959960937" width="99" height="0.19999999999998863"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="6" name="Plot">
+                <position x="621.9994967793881" y="210.62659380692168" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.37515096618357485" centery="0.250975800156128" posx="0.25050322061191627" posy="0.16809784022898777" leftx="0.25050322061191627" lefty="0.3338537600832683" rightx="0.4997987117552335" righty="0.3338537600832683" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="224" height="21"/>
+                    <relativesize width="0.4415010345647224" height="0.14463590116734934" centerx="0.2539980814377063" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.4747485987200675" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_4he\_hsw\_temperature vs INDEX (C6)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1034334672"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-150.39183959960937" width="99" height="0.19999999999998863"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="8" name="Plot">
+                <position x="1860.0009057971015" y="210.62659380692168" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.8737419484702094" centery="0.250975800156128" posx="0.7490942028985508" posy="0.16809784022898777" leftx="0.7490942028985508" lefty="0.3338537600832683" rightx="0.998389694041868" righty="0.3338537600832683" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="224" height="21"/>
+                    <relativesize width="0.4415010345647224" height="0.14463590116734934" centerx="0.2539980814377063" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.4747485987200675" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_hawkeye\_temperature vs INDEX (C8)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="10" name="Plot">
+                <position x="621.9994967793881" y="418.3187613843352" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.37515096618357485" centery="0.4167317200104086" posx="0.25050322061191627" posy="0.3338537600832683" leftx="0.25050322061191627" lefty="0.4996096799375488" rightx="0.4997987117552335" righty="0.4996096799375488" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.13245940092257" z="500"/>
+                    <rect x="0" y="0" width="214" height="21"/>
+                    <relativesize width="0.4217911669502258" height="0.14463590116734934" centerx="0.24414314763045805" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319471" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.45503873110557097" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_lw\_coll\_temperature vs INDEX (C10)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="986776512"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1034685264"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="295.2709045410156" width="99" height="0.007598876953125"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="12" name="Plot">
+                <position x="1860.0009057971015" y="418.3187613843352" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.8737419484702094" centery="0.4167317200104086" posx="0.7490942028985508" posy="0.3338537600832683" leftx="0.7490942028985508" lefty="0.4996096799375488" rightx="0.998389694041868" righty="0.4996096799375488" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.13245940092257" z="500"/>
+                    <rect x="0" y="0" width="224" height="21"/>
+                    <relativesize width="0.4415010345647224" height="0.14463590116734934" centerx="0.2539980814377063" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319471" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.4747485987200675" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_4he\_film\_temperature vs INDEX (C12)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1028976960"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-100.26518402099609" width="99" height="0.19999999999998863"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="14" name="Plot">
+                <position x="621.9994967793881" y="626.0109289617486" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.6921675774135"/>
+                <relativesize width="0.24929549114331723" height="0.16575591985428054" centerx="0.37515096618357485" centery="0.5824876398646891" posx="0.25050322061191627" posy="0.4996096799375488" leftx="0.25050322061191627" lefty="0.6653655997918293" rightx="0.4997987117552335" righty="0.6653655997918293" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922563" z="500"/>
+                    <rect x="0" y="0" width="223" height="21"/>
+                    <relativesize width="0.4395300478032727" height="0.1446359011673493" centerx="0.2530125880569815" centery="0.1730979006668693" posx="0.03324756415534515" posy="0.10077995008319464" leftx="0.03324756415534515" lefty="0.24541585125054396" rightx="0.47277761195861784" righty="0.24541585125054396" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_4k\_plate\_temperature vs INDEX (C14)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="986776512"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1035038672"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="295.572998046875" width="99" height="0.008941650390625"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="16" name="Plot">
+                <position x="1860.0009057971015" y="626.0109289617486" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.6921675774135"/>
+                <relativesize width="0.24929549114331723" height="0.16575591985428054" centerx="0.8737419484702094" centery="0.5824876398646891" posx="0.7490942028985508" posy="0.4996096799375488" leftx="0.7490942028985508" lefty="0.6653655997918293" rightx="0.998389694041868" righty="0.6653655997918293" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922563" z="500"/>
+                    <rect x="0" y="0" width="225" height="21"/>
+                    <relativesize width="0.443472021326172" height="0.1446359011673493" centerx="0.25498357481843115" centery="0.1730979006668693" posx="0.03324756415534515" posy="0.10077995008319464" leftx="0.03324756415534515" lefty="0.24541585125054396" rightx="0.47671958548151716" righty="0.24541585125054396" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_vcs1\_hex\_temperature vs INDEX (C16)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1029137600"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="295.5037841796875" width="99" height="0.008819580078125"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="18" name="Plot">
+                <position x="621.9994967793881" y="833.7030965391621" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.6921675774135"/>
+                <relativesize width="0.24929549114331723" height="0.16575591985428054" centerx="0.37515096618357485" centery="0.7482435597189696" posx="0.25050322061191627" posy="0.6653655997918293" leftx="0.25050322061191627" lefty="0.8311215196461099" rightx="0.4997987117552335" righty="0.8311215196461099" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922563" z="500"/>
+                    <rect x="0" y="0" width="225" height="21"/>
+                    <relativesize width="0.443472021326172" height="0.1446359011673493" centerx="0.25498357481843115" centery="0.1730979006668693" posx="0.03324756415534515" posy="0.10077995008319464" leftx="0.03324756415534515" lefty="0.24541585125054396" rightx="0.47671958548151716" righty="0.24541585125054396" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_vcs2\_hex\_temperature vs INDEX (C18)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="986776512"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1035392080"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="295.10565185546875" width="99" height="0.007568359375"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="20" name="Plot">
+                <position x="1860.0009057971015" y="833.7030965391621" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.6921675774135"/>
+                <relativesize width="0.24929549114331723" height="0.16575591985428054" centerx="0.8737419484702094" centery="0.7482435597189696" posx="0.7490942028985508" posy="0.6653655997918293" leftx="0.7490942028985508" lefty="0.8311215196461099" rightx="0.998389694041868" righty="0.8311215196461099" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922563" z="500"/>
+                    <rect x="0" y="0" width="227" height="21"/>
+                    <relativesize width="0.4474139948490713" height="0.1446359011673493" centerx="0.2569545615798808" centery="0.1730979006668693" posx="0.03324756415534515" posy="0.10077995008319464" leftx="0.03324756415534515" lefty="0.24541585125054396" rightx="0.4806615590044165" righty="0.24541585125054396" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_4k\_shield\_temperature vs INDEX (C20)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1035568160"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="96"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="22" name="Plot">
+                <position x="621.9994967793881" y="1041.3952641165756" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.37515096618357485" centery="0.9139994795732502" posx="0.25050322061191627" posy="0.8311215196461099" leftx="0.25050322061191627" lefty="0.9968774395003903" rightx="0.4997987117552335" righty="0.9968774395003903" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="221" height="21"/>
+                    <relativesize width="0.4355880742803734" height="0.14463590116734934" centerx="0.2510416012955318" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.46883563843571857" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_vcs1\_filt\_temperature vs INDEX (C22)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1035744496"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1029444288"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="5.8766297265136735" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="24" name="Plot">
+                <position x="1860.0009057971015" y="1041.3952641165756" z="500"/>
+                <rect x="0" y="0" width="619.0007045088566" height="207.69216757741347"/>
+                <relativesize width="0.24929549114331723" height="0.1657559198542805" centerx="0.8737419484702094" centery="0.9139994795732502" posx="0.7490942028985508" posy="0.8311215196461099" leftx="0.7490942028985508" lefty="0.9968774395003903" rightx="0.998389694041868" righty="0.9968774395003903" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="106.50911179333173" y="31.132459400922567" z="500"/>
+                    <rect x="0" y="0" width="234" height="21"/>
+                    <relativesize width="0.4612109021792189" height="0.14463590116734934" centerx="0.2638530152449546" centery="0.1730979006668694" posx="0.03324756415534515" posy="0.10077995008319468" leftx="0.03324756415534515" lefty="0.24541585125054405" rightx="0.49445846633456403" righty="0.24541585125054405" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="diode\_lw\_grating\_temperature vs INDEX (C24)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="0"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="986776512"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="5.8766297265136735" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-56.831536865234376" width="99" height="0.20000000000000284"/>
+            </plot>
+        </view>
+        <view name="RTDs" width="2483" height="1253" color="#ffffff" style="0">
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="39" name="Plot">
+                <position x="1241.5" y="938.25" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.6244464573268921" centery="0.8725079744816587" posx="0.4997987117552335" posy="0.7482057416267942" leftx="0.4997987117552335" lefty="0.9968102073365231" rightx="0.7490942028985508" righty="0.9968102073365231" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="225" height="21"/>
+                    <relativesize width="0.5016547639784011" height="0.0856269113149847" centerx="0.28816785131814243" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.5389952333073429" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_lw\_fpu\_350\_temperature vs INDEX (C39)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="0.2598153054714203" width="99" height="0.2508297264575958"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="37" name="Plot">
+                <position x="3" y="938.25" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.12585547504025765" centery="0.8725079744816587" posx="0.0012077294685990338" posy="0.7482057416267942" leftx="0.0012077294685990338" lefty="0.9968102073365231" rightx="0.25050322061191627" righty="0.9968102073365231" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="221" height="21"/>
+                    <relativesize width="0.4927364570632294" height="0.0856269113149847" centerx="0.28370869786055664" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.5300769263921714" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_lw\_250\_fin\_temperature vs INDEX (C37)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-0.2576543688774109" width="99" height="0.30880412831902504"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="35" name="Plot">
+                <position x="1241.5" y="626.5" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.6244464573268921" centery="0.6239035087719298" posx="0.4997987117552335" posy="0.4996012759170654" leftx="0.4997987117552335" lefty="0.7482057416267942" rightx="0.7490942028985508" righty="0.7482057416267942" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="215" height="21"/>
+                    <relativesize width="0.47935899669047205" height="0.0856269113149847" centerx="0.27701996767417797" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.516699466019414" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_4he\_head\_temperature vs INDEX (C35)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-2741.042724609375" width="99" height="47171631797.042725"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="33" name="Plot">
+                <position x="3" y="626.5" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.12585547504025765" centery="0.6239035087719298" posx="0.0012077294685990338" posy="0.4996012759170654" leftx="0.0012077294685990338" lefty="0.7482057416267942" rightx="0.25050322061191627" righty="0.7482057416267942" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="196" height="21"/>
+                    <relativesize width="0.4369970388434071" height="0.0856269113149847" centerx="0.2558389887506455" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.47433750817234904" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_lw\_filt\_temperature vs INDEX (C33)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="0.05496814846992493" width="99" height="16.36466571688652"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="31" name="Plot">
+                <position x="1241.5" y="314.75" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.6244464573268921" centery="0.37529904306220097" posx="0.4997987117552335" posy="0.2509968102073365" leftx="0.4997987117552335" lefty="0.4996012759170654" rightx="0.7490942028985508" righty="0.4996012759170654" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="181" height="21"/>
+                    <relativesize width="0.4035533879115137" height="0.0856269113149847" centerx="0.23911716328469879" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.44089385724045566" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_1\_7\_temperature vs INDEX (C31)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-15.1" width="99" height="0.1999999999999993"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="29" name="Plot">
+                <position x="3" y="314.75" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.12585547504025765" centery="0.37529904306220097" posx="0.0012077294685990338" posy="0.2509968102073365" leftx="0.0012077294685990338" lefty="0.4996012759170654" rightx="0.25050322061191627" righty="0.4996012759170654" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="181" height="21"/>
+                    <relativesize width="0.4035533879115137" height="0.0856269113149847" centerx="0.23911716328469879" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.44089385724045566" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_1\_5\_temperature vs INDEX (C29)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-15.1" width="99" height="0.1999999999999993"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="27" name="Plot">
+                <position x="1241.5" y="3" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.6244464573268921" centery="0.12669457735247208" posx="0.4997987117552335" posy="0.0023923444976076554" leftx="0.4997987117552335" lefty="0.2509968102073365" rightx="0.7490942028985508" righty="0.2509968102073365" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="181" height="21"/>
+                    <relativesize width="0.4035533879115137" height="0.0856269113149847" centerx="0.23911716328469879" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.44089385724045566" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_1\_3\_temperature vs INDEX (C27)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="1035114496"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-15.1" width="99" height="0.1999999999999993"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="25" name="Plot">
+                <position x="3" y="3" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.12585547504025765" centery="0.12669457735247208" posx="0.0012077294685990338" posy="0.0023923444976076554" leftx="0.0012077294685990338" lefty="0.2509968102073365" rightx="0.25050322061191627" righty="0.2509968102073365" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="181" height="21"/>
+                    <relativesize width="0.4035533879115137" height="0.0856269113149847" centerx="0.23911716328469879" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.44089385724045566" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_1\_1\_temperature vs INDEX (C25)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="19"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="19"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-15.1" width="99" height="0.1999999999999993"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="26" name="Plot">
+                <position x="622.25" y="3" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.37515096618357485" centery="0.12669457735247208" posx="0.25050322061191627" posy="0.0023923444976076554" leftx="0.25050322061191627" lefty="0.2509968102073365" rightx="0.4997987117552335" righty="0.2509968102073365" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="181" height="21"/>
+                    <relativesize width="0.4035533879115137" height="0.0856269113149847" centerx="0.23911716328469879" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.44089385724045566" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_1\_2\_temperature vs INDEX (C26)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1033704168"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="6553714"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-15.1" width="99" height="0.1999999999999993"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="28" name="Plot">
+                <position x="1860.75" y="3" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.8737419484702094" centery="0.12669457735247208" posx="0.7490942028985508" posy="0.0023923444976076554" leftx="0.7490942028985508" lefty="0.2509968102073365" rightx="0.998389694041868" righty="0.2509968102073365" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="181" height="21"/>
+                    <relativesize width="0.4035533879115137" height="0.0856269113149847" centerx="0.23911716328469879" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.44089385724045566" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_1\_4\_temperature vs INDEX (C28)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-15.1" width="99" height="0.1999999999999993"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="30" name="Plot">
+                <position x="622.25" y="314.75" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.37515096618357485" centery="0.37529904306220097" posx="0.25050322061191627" posy="0.2509968102073365" leftx="0.25050322061191627" lefty="0.4996012759170654" rightx="0.4997987117552335" righty="0.4996012759170654" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="181" height="21"/>
+                    <relativesize width="0.4035533879115137" height="0.0856269113149847" centerx="0.23911716328469879" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.44089385724045566" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_1\_6\_temperature vs INDEX (C30)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-15.1" width="99" height="0.1999999999999993"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="32" name="Plot">
+                <position x="1860.75" y="314.75" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.8737419484702094" centery="0.37529904306220097" posx="0.7490942028985508" posy="0.2509968102073365" leftx="0.7490942028985508" lefty="0.4996012759170654" rightx="0.998389694041868" righty="0.4996012759170654" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="203" height="21"/>
+                    <relativesize width="0.4526040759449574" height="0.0856269113149847" centerx="0.26364250730142064" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.4899445452738993" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_ic\_head\_temperature vs INDEX (C32)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="0.03372453153133392" width="99" height="10326.382291093469"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="34" name="Plot">
+                <position x="622.25" y="626.5" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.37515096618357485" centery="0.6239035087719298" posx="0.25050322061191627" posy="0.4996012759170654" leftx="0.25050322061191627" lefty="0.7482057416267942" rightx="0.4997987117552335" righty="0.7482057416267942" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="207" height="21"/>
+                    <relativesize width="0.4615223828601289" height="0.0856269113149847" centerx="0.26810166075900643" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.49886285218907084" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_uc\_head\_temperature vs INDEX (C34)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-2.794400930404663" width="99" height="3.8484870195388794"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="36" name="Plot">
+                <position x="1860.75" y="626.5" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.8737419484702094" centery="0.6239035087719298" posx="0.7490942028985508" posy="0.4996012759170654" leftx="0.7490942028985508" lefty="0.7482057416267942" rightx="0.998389694041868" righty="0.7482057416267942" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="217" height="21"/>
+                    <relativesize width="0.48381815014805785" height="0.0856269113149847" centerx="0.2792495444029709" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.5211586194769998" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_lw\_fpu\_1k\_temperature vs INDEX (C36)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-0.851215660572052" width="99" height="1.1693530976772308"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="38" name="Plot">
+                <position x="622.25" y="938.25" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.37515096618357485" centery="0.8725079744816587" posx="0.25050322061191627" posy="0.7482057416267942" leftx="0.25050322061191627" lefty="0.9968102073365231" rightx="0.4997987117552335" righty="0.9968102073365231" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="225" height="21"/>
+                    <relativesize width="0.5016547639784011" height="0.0856269113149847" centerx="0.28816785131814243" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.5389952333073429" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_lw\_fpu\_250\_temperature vs INDEX (C38)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="1190.924169921875" width="99" height="0.1999999999998181"/>
+            </plot>
+            <plot tiedxzoom="false" tiedyzoom="false" leftlabelvisible="true" bottomlabelvisible="true" rightlabelvisible="true" toplabelvisible="true" globalfont="Ubuntu,13,-1,5,50,0,0,0,0,0" globalfontscale="6.32379000772445" globalfontcolor="#000000" showlegend="true" hidebottomaxislabel="false" hidetopaxislabel="false" hideleftaxislabel="false" hiderightaxislabel="false" numberaxislabelscale="true" initialPlotNum="40" name="Plot">
+                <position x="1860.75" y="938.25" z="500"/>
+                <rect x="0" y="0" width="619.25" height="311.75"/>
+                <relativesize width="0.24929549114331723" height="0.24860446570972886" centerx="0.8737419484702094" centery="0.8725079744816587" posx="0.7490942028985508" posy="0.7482057416267942" leftx="0.7490942028985508" lefty="0.9968102073365231" rightx="0.998389694041868" righty="0.9968102073365231" fixaspect="false" lockpostodata="false"/>
+                <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                    <brush color="#000000" alpha="1" style="1"/>
+                </pen>
+                <brush color="#ffffff" alpha="1" style="0"/>
+                <legend auto="true" title="" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="4" color="#000000" verticaldisplay="false" name="Legend">
+                    <position x="165.48215893886373" y="35.05227272727272" z="500"/>
+                    <rect x="0" y="0" width="222" height="21"/>
+                    <relativesize width="0.4949660337920223" height="0.0856269113149847" centerx="0.2848234862249531" centery="0.11845982763413954" posx="0.03734046932894196" posy="0.07564637197664718" leftx="0.03734046932894196" lefty="0.1612732832916319" rightx="0.5323065031209643" righty="0.1612732832916319" fixaspect="false" lockpostodata="false"/>
+                    <transform m11="1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="0" m32="0" m33="1"/>
+                    <pen style="1" width="0" miterlimit="2" cap="16" joinStyle="64">
+                        <brush color="#000000" alpha="1" style="1"/>
+                    </pen>
+                    <brush color="#ffffff" alpha="1" style="0"/>
+                </legend>
+                <cartesianrender name="Cartesian Plot" type="1">
+                    <relation tag="rtd\_lw\_fpu\_cor\_temperature vs INDEX (C40)"/>
+                </cartesianrender>
+                <plotaxis id="xaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="true" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotaxis id="yaxis" visible="true" log="false" reversed="false" autobaseoffset="true" baseoffset="false" forceoffsetmin="false" interpret="false" interpretation="1" display="4" displayformatstring="hh:mm:ss.zzz" majortickmode="5" minortickcount="5" autominortickcount="true" drawmajorticks="true" drawminorticks="true" drawmajorgridlines="true" drawminorgridlines="false" drawmajorgridlinecolor="#a0a0a4" drawminorgridlinecolor="#a0a0a4" drawmajorgridlinestyle="2" drawminorgridlinestyle="2" drawmajorgridlinewidth="1" drawminorgridlinewidth="1" significantdigits="9" rotation="0" zoommode="0" timezonename="GMT" timezoneoffset="0">
+                    <plotmarkers xaxis="false" linecolor="#000000" linestyle="1" linewidth="1" curvemode="-1"/>
+                </plotaxis>
+                <plotlabel id="leftlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="rightlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="toplabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="bottomlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <plotlabel id="numberlabel" visible="true" overridetext="" autolabel="true" font="Ubuntu,13,-1,5,50,0,0,0,0,0" fontscale="6.32379000772445" fontcolor="#000000" fontuseglobal="true"/>
+                <projectionrect x="454" y="-0.27944403886795044" width="99" height="0.49619781970977783"/>
+            </plot>
+        </view>
+    </graphics>
+</kst>

--- a/mcp/commanding/commands.c
+++ b/mcp/commanding/commands.c
@@ -2833,7 +2833,6 @@ void InitCommandData()
     CommandData.sc_trigger.starcam_image_timeout_1 = 2;
     CommandData.sc_trigger.starcam_image_timeout_2 = 2;
 
-<<<<<<< shubh-hk
     CommandData.cryo_command.command = 0;
     CommandData.cryo_command.command_ready = 0;
     CommandData.cryo_command.param1 = 0;
@@ -2841,7 +2840,7 @@ void InitCommandData()
     CommandData.cryo_command.param3 = 0;
     CommandData.cryo_command.param4 = 0;
     CommandData.cryo_command.param5 = 0;
-=======
+
     // RFSOC commanding
     CommandData.rfsoc_commands1.command_ready = 0;
     CommandData.rfsoc_commands1.command = 0;
@@ -2860,7 +2859,6 @@ void InitCommandData()
     CommandData.rfsoc_commands2.param3 = 0;
     CommandData.rfsoc_commands2.param4 = 0;
     CommandData.rfsoc_commands2.param5 = 0;
->>>>>>> main
 
     // EVTM telemetry
     CommandData.evtm_los_enabled = 1;

--- a/mcp/commanding/commands.c
+++ b/mcp/commanding/commands.c
@@ -464,7 +464,41 @@ void SingleCommand(enum singleCommand command, int scheduled)
             CommandData.motor_power.relay_10_off = 1;
             CommandData.motor_power.update_pbob = 1;
             break;
+
         /* HOUSEKEEPING */
+        // cryo commands
+        case enable_cryo_pid:
+            CommandData.cryo_command.command = 1;
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case disable_cryo_pid:
+            CommandData.cryo_command.command = 2;
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case reset_cryo_pid:
+            CommandData.cryo_command.command = 3;
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case start_fridge_cycle:
+            CommandData.cryo_command.command = 4;
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case stop_fridge_cycle:
+            CommandData.cryo_command.command = 5;
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case enable_fridge_cycle:
+            CommandData.cryo_command.command = 6;
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case disable_fridge_cycle:
+            CommandData.cryo_command.command = 7;
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case skip_to_next_fridge_stage:
+            CommandData.cryo_command.command = 8;
+            CommandData.cryo_command.command_ready = 1;
+            break;
 
         /* DETECTORS */
 
@@ -1014,6 +1048,62 @@ void MultiCommand(enum multiCommand command, double *rvalues,
 //   Pointing Modes
   switch (command) {
         /* HOUSEKEEPING */
+        case disable_diode:
+            CommandData.cryo_command.command = 20;
+            CommandData.cryo_command.param1 = ivalues[0];
+            CommandData.cryo_command.param2 = ivalues[1];
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case enable_diode_ac:
+            CommandData.cryo_command.command = 21;
+            CommandData.cryo_command.param1 = ivalues[0];
+            CommandData.cryo_command.param2 = ivalues[1];
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case enable_diode_dc:
+            CommandData.cryo_command.command = 22;
+            CommandData.cryo_command.param1 = ivalues[0];
+            CommandData.cryo_command.param2 = ivalues[1];
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case set_rtd_logdac:
+            CommandData.cryo_command.command = 30;
+            CommandData.cryo_command.param1 = ivalues[0];
+            CommandData.cryo_command.param2 = ivalues[1];
+            CommandData.cryo_command.param3 = ivalues[2];
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case set_rtd_muv:
+            CommandData.cryo_command.command = 31;
+            CommandData.cryo_command.param1 = ivalues[0];
+            CommandData.cryo_command.param2 = ivalues[1];
+            CommandData.cryo_command.param3 = rvalues[2];
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case enable_heater:
+            CommandData.cryo_command.command = 40;
+            CommandData.cryo_command.param1 = ivalues[0];
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case disable_heater:
+            CommandData.cryo_command.command = 41;
+            CommandData.cryo_command.param1 = ivalues[0];
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case set_heater_v:
+            CommandData.cryo_command.command = 42;
+            CommandData.cryo_command.param1 = ivalues[0];
+            CommandData.cryo_command.param2 = rvalues[1];
+            CommandData.cryo_command.command_ready = 1;
+            break;
+        case set_cryo_pid:
+            CommandData.cryo_command.command = 50;
+            CommandData.cryo_command.param1 = rvalues[0];
+            CommandData.cryo_command.param2 = rvalues[1];
+            CommandData.cryo_command.param3 = rvalues[2];
+            CommandData.cryo_command.param4 = rvalues[3];
+            CommandData.cryo_command.command_ready = 1;
+            break;
 
         /* DETECTORS */
 
@@ -2643,6 +2733,14 @@ void InitCommandData()
     CommandData.sc_trigger.starcam_image_timeout_update = 0;
     CommandData.sc_trigger.starcam_image_timeout_1 = 2;
     CommandData.sc_trigger.starcam_image_timeout_2 = 2;
+
+    CommandData.cryo_command.command = 0;
+    CommandData.cryo_command.command_ready = 0;
+    CommandData.cryo_command.param1 = 0;
+    CommandData.cryo_command.param2 = 0;
+    CommandData.cryo_command.param3 = 0;
+    CommandData.cryo_command.param4 = 0;
+    CommandData.cryo_command.param5 = 0;
 
     // EVTM telemetry
     CommandData.evtm_los_enabled = 1;

--- a/mcp/housekeeping/CMakeLists.txt
+++ b/mcp/housekeeping/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(housekeeping STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/inner_frame_power.c
     ${CMAKE_CURRENT_SOURCE_DIR}/gondola_thermometry.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cryo_tauhk.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/cryo_tauhk_cmd.c
     ${CMAKE_CURRENT_SOURCE_DIR}/labjack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/labjack_functions.c
     ${CMAKE_CURRENT_SOURCE_DIR}/loop_timing.c

--- a/mcp/housekeeping/cryo_tauhk.c
+++ b/mcp/housekeeping/cryo_tauhk.c
@@ -110,7 +110,7 @@ void udp_receive_cryo_hk_1Hz(void *arg) {
             continue; // retry on error
         }
         // Process the received data
-        blast_info("Received cryo HK 1Hz data of size %zd bytes", n);
+        // blast_info("Received cryo HK 1Hz data of size %zd bytes", n);
         memcpy(&hk_data_one, buffer, sizeof(HKDataOne));
     }
 }
@@ -140,7 +140,7 @@ void udp_receive_cryo_hk_20Hz(void *arg) {
             continue; // retry on error
         }
         // Process the received data
-        blast_info("Received cryo HK 20Hz data of size %zd bytes", n);
+        // blast_info("Received cryo HK 20Hz data of size %zd bytes", n);
         memcpy(&hk_data_twenty, buffer, sizeof(HKDataTwenty));
     }
 }
@@ -170,7 +170,7 @@ void udp_receive_cryo_hk_80Hz(void *arg) {
             continue; // retry on error
         }
         // Process the received data
-        blast_info("Received cryo HK 80Hz data of size %zd bytes", n);
+        // blast_info("Received cryo HK 80Hz data of size %zd bytes", n);
         memcpy(&hk_data_eighty, buffer, sizeof(HKDataEighty));
     }
 }

--- a/mcp/housekeeping/cryo_tauhk_cmd.c
+++ b/mcp/housekeeping/cryo_tauhk_cmd.c
@@ -55,7 +55,7 @@ extern int16_t InCharge;
  * @param packet packet that I want to fill and 
  * @param commands pointer to the  commands substructure in commanddata (set by thread)
  */
-void generate_command_packet(struct cryo_command_data* packet, cryo_command_t* commands) {
+void generate_cryo_command_packet(struct cryo_command_data* packet, cryo_command_t* commands) {
     packet->incharge = InCharge;
     packet->command_num = commands->command;
     packet->param1 = commands->param1;
@@ -63,7 +63,7 @@ void generate_command_packet(struct cryo_command_data* packet, cryo_command_t* c
     packet->param3 = commands->param3;
     packet->param4 = commands->param4;
     packet->param5 = commands->param5;
-    reset_command_packet(commands);
+    reset_cryo_command_packet(commands);
 };
 
 /**
@@ -71,7 +71,7 @@ void generate_command_packet(struct cryo_command_data* packet, cryo_command_t* c
  * copied from rfsoc commanding code
  * @param packet packet to reset to 0
  */
-void reset_command_packet(struct cryo_command_data* packet) {
+void reset_cryo_command_packet(struct cryo_command_data* packet) {
     memset(packet, 0, sizeof(*packet));
 }
 
@@ -82,7 +82,7 @@ void reset_command_packet(struct cryo_command_data* packet) {
  * the cryo commanding information, copied from rfsoc commanding code
  * @return int 
  */
-int check_command_ready(cryo_command_t* commands) {
+int check_cryo_command_ready(cryo_command_t* commands) {
     if (commands->command_ready == 1) {
         commands->command_ready = 0;
         return 1;
@@ -147,12 +147,12 @@ void * send_cryo_commands(void* args) {
         // now the "str" is packed with the IP address string
         // first time setup of the socket is done
         }
-        packet_status = check_command_ready(command_pointer);
+        packet_status = check_cryo_command_ready(command_pointer);
         if (packet_status == 1) {
             blast_info("Got a cryo command packet,  going into send!\n");
         }
         if (packet_status) {
-            generate_command_packet(&cryo_packet, command_pointer);
+            generate_cryo_command_packet(&cryo_packet, command_pointer);
             if (!strcmp(socket_target->ipAddr, ipAddr)) {
                 packet_status = 0;
                 length = sizeof(cryo_packet);

--- a/mcp/housekeeping/cryo_tauhk_cmd.c
+++ b/mcp/housekeeping/cryo_tauhk_cmd.c
@@ -1,0 +1,176 @@
+/* 
+ * cryo_tauhk_cmd.c: interface for cryo commanding via TauHK
+ * 
+ * This software  is copyright 
+ *  (C) University of Pennsylvania, Philadelphia 2026
+ *
+ * This file is part of mcp, as used for the Terahertz Intensity Mapper (TIM).
+ *
+ * mcp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mcp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with mcp; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * History:
+ * Created on: April 24, 2026 by Shubh Agrawal
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <netdb.h>
+#include <arpa/inet.h> // socket stuff
+#include <netinet/in.h> // socket stuff
+#include <sys/socket.h> // socket stuff
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <signal.h>
+#include <errno.h>
+
+#include "socket_utils.h"
+#include "command_struct.h"
+#include "mcp.h"
+#include "channels_tng.h"
+#include "lut.h"
+#include "tx.h"
+#include "cryo_tauhk_cmd.h"
+#include "blast.h"
+
+extern int16_t InCharge;
+
+/**
+ * @brief copy over command into a packet to send to cryo commander
+ * copied from rfsoc commanding code
+ * @param packet packet that I want to fill and 
+ * @param commands pointer to the  commands substructure in commanddata (set by thread)
+ */
+void generate_command_packet(struct cryo_command_data* packet, cryo_command_t* commands) {
+    packet->incharge = InCharge;
+    packet->command_num = commands->command;
+    packet->param1 = commands->param1;
+    packet->param2 = commands->param2;
+    packet->param3 = commands->param3;
+    packet->param4 = commands->param4;
+    packet->param5 = commands->param5;
+    reset_command_packet(commands);
+};
+
+/**
+ * @brief to be called after sending the packet to ensure we don't send multiple copies
+ * copied from rfsoc commanding code
+ * @param packet packet to reset to 0
+ */
+void reset_command_packet(struct cryo_command_data* packet) {
+    memset(packet, 0, sizeof(*packet));
+}
+
+/**
+ * @brief 
+ * 
+ * @param commands pointer to the associated commanddata substruct that contains
+ * the cryo commanding information, copied from rfsoc commanding code
+ * @return int 
+ */
+int check_command_ready(cryo_command_t* commands) {
+    if (commands->command_ready == 1) {
+        commands->command_ready = 0;
+        return 1;
+    }
+    return 0;
+};
+
+// here goes the actual thread that we call
+void * send_cryo_commands(void* args) {
+    struct cryo_command_data cryo_packet;
+    cryo_command_t* command_pointer;
+    struct socketData * socket_target = args;
+    int sleep_interval_usec = 500000; // sleep for 0.5 seconds between attempts to send packets
+    int first_time = 1;
+    int sockfd;
+    struct addrinfo hints;
+    struct addrinfo *servinfo;
+    struct addrinfo *servinfoCheck;
+    int returnval;
+    int bytes_sent;
+    int length;
+    int *retval;
+    char message_str[40];
+    char ipAddr[INET_ADDRSTRLEN];
+    int which_sc;
+    int packet_status = 0;
+    // check which fc I am and set my pointer properly
+    command_pointer = &CommandData.cryo_command;
+    while (1) {
+        if (first_time == 1) {
+            first_time = 0;
+            memset(&hints, 0, sizeof(hints));
+            hints.ai_family = AF_INET; // set to AF_INET to use IPv4
+            hints.ai_socktype = SOCK_DGRAM;
+            // fill out address info and return if it fails.
+            if ((returnval = getaddrinfo(socket_target->ipAddr, socket_target->port, &hints, &servinfo)) != 0) {
+                blast_err("getaddrinfo: %s\n", gai_strerror(returnval));
+                return NULL;
+        }
+        // now we make a socket with this info
+        for (servinfoCheck = servinfo; servinfoCheck != NULL; servinfoCheck = servinfoCheck->ai_next) {
+            if ((sockfd = socket(servinfoCheck->ai_family,
+             servinfoCheck->ai_socktype, servinfoCheck->ai_protocol)) == -1) {
+                perror("talker: socket");
+                continue;
+            }
+            break;
+        }
+        // check to see if we made a socket
+        if (servinfoCheck == NULL) {
+            // set status to 0 (dead) if this fails
+            blast_err("talker: failed to create socket\n");
+            return NULL;
+        }
+        // if we pass all of these checks then
+        // we set up the print statement vars
+        // need to cast the socket address to an INET still address
+        struct sockaddr_in *ipv = (struct sockaddr_in *)servinfo->ai_addr;
+        // then pass the pointer to translation and put it in a string
+        inet_ntop(AF_INET, &(ipv->sin_addr), ipAddr, INET_ADDRSTRLEN);
+        blast_info("IP target is: %s\n", ipAddr);
+        // now the "str" is packed with the IP address string
+        // first time setup of the socket is done
+        }
+        packet_status = check_command_ready(command_pointer);
+        if (packet_status == 1) {
+            blast_info("Got a cryo command packet,  going into send!\n");
+        }
+        if (packet_status) {
+            generate_command_packet(&cryo_packet, command_pointer);
+            if (!strcmp(socket_target->ipAddr, ipAddr)) {
+                packet_status = 0;
+                length = sizeof(cryo_packet);
+                if ((bytes_sent = sendto(sockfd, &cryo_packet, length, 0,
+                    servinfo->ai_addr, servinfo->ai_addrlen)) == -1) {
+                    perror("talker: sendto");
+                }
+                blast_info("sent packet to %s port %s\n", socket_target->ipAddr, socket_target->port);
+                blast_info("data was %i %i %f %f %f %f %f", cryo_packet.incharge,
+                    cryo_packet.command_num, cryo_packet.param1, cryo_packet.param2, cryo_packet.param3,
+                    cryo_packet.param4, cryo_packet.param5);
+            } else {
+                blast_err("Target destination %s differs from thread target %s.\n", socket_target->ipAddr, ipAddr);
+            }
+        }
+        usleep(sleep_interval_usec);
+    }
+    freeaddrinfo(servinfo);
+    close(sockfd);
+    return NULL;
+};

--- a/mcp/include/command_struct.h
+++ b/mcp/include/command_struct.h
@@ -393,6 +393,19 @@ typedef struct {
   int starcam_image_timeout_update;
 } sc_force_trigger_t;
 
+/**
+ * @brief cryo housekeeping commanding structure
+ * 
+ */
+typedef struct {
+  int command_ready;
+  int command;
+  float param1;
+  float param2;
+  float param3;
+  float param4;
+  float param5;
+} cryo_command_t;
 
 /**
  * @brief full command data structure containing relevant cross-mcp information for commanding
@@ -510,6 +523,8 @@ struct CommandDataStruct {
   sc_force_trigger_t sc_trigger;
   float sc_az_vel_limit;
   int update_position_sc; // should we automatically append lat/lon/alt to command packets
+
+  cryo_command_t cryo_command;
 
   lj_pbob_t if_power;
 

--- a/mcp/include/command_struct.h
+++ b/mcp/include/command_struct.h
@@ -394,31 +394,34 @@ typedef struct {
 } sc_force_trigger_t;
 
 /**
-<<<<<<< shubh-hk
  * @brief cryo housekeeping commanding structure
-=======
- * @brief rfsoc commanding struct definition
->>>>>>> main
  * 
  */
 typedef struct {
   int command_ready;
-<<<<<<< shubh-hk
-=======
-  int drone;
->>>>>>> main
   int command;
   float param1;
   float param2;
   float param3;
   float param4;
   float param5;
-<<<<<<< shubh-hk
 } cryo_command_t;
-=======
+
+/**
+ * @brief rfsoc commanding struct definition
+ * 
+ */
+typedef struct {
+  int command_ready;
+  int drone;
+  int command;
+  float param1;
+  float param2;
+  float param3;
+  float param4;
+  float param5;
 } rfsoc_commands_t;
 
->>>>>>> main
 
 /**
  * @brief full command data structure containing relevant cross-mcp information for commanding
@@ -537,12 +540,10 @@ struct CommandDataStruct {
   float sc_az_vel_limit;
   int update_position_sc; // should we automatically append lat/lon/alt to command packets
 
-<<<<<<< shubh-hk
   cryo_command_t cryo_command;
-=======
+  
   rfsoc_commands_t rfsoc_commands1;
   rfsoc_commands_t rfsoc_commands2;
->>>>>>> main
 
   lj_pbob_t if_power;
 

--- a/mcp/include/cryo_tauhk_cmd.h
+++ b/mcp/include/cryo_tauhk_cmd.h
@@ -1,0 +1,50 @@
+/* 
+ * cryo_tauhk_cmd.h: interface for cryo commanding via TauHK
+ * 
+ * This software  is copyright 
+ *  (C) University of Pennsylvania, Philadelphia 2026
+ *
+ * This file is part of mcp, as used for the Terahertz Intensity Mapper (TIM).
+ *
+ * mcp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mcp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with mcp; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * History:
+ * Created on: April 24, 2026 by Shubh Agrawal
+ */
+
+
+#ifndef INCLUDE_CRYO_HK_CMD_H
+#define INCLUDE_CRYO_HK_CMD_H
+
+#include "mcp.h"
+#define CRYO_HK_CMD_IP "192.168.0.69"
+#define CRYO_HK_CMD_PORT_FC1 "1567"
+#define CRYO_HK_CMD_PORT_FC2 "1568" // two ports to make Ian happy
+
+extern int16_t InCharge;
+
+typedef struct cryo_command_data {
+    int incharge;
+    int command_num;
+    float param1;
+    float param2;
+    float param3;
+    float param4;
+    float param5;
+} cryo_command_data;
+
+void * send_cryo_commands(void* args);
+
+#endif

--- a/mcp/mcp.c
+++ b/mcp/mcp.c
@@ -98,6 +98,7 @@
 #include "socket_utils.h"
 #include "gondola_thermometry.h"
 #include "cryo_tauhk.h"
+#include "cryo_tauhk_cmd.h"
 #include "star_camera_transmit.h"
 #include "star_camera_solutions.h"
 #include "star_camera_receive.h"
@@ -645,6 +646,17 @@ blast_info("Finished initializing Beaglebones..."); */
        xsc_trigger(0, 0);
        xsc_trigger(1, 0);
   }
+
+
+  // cryo tauhk commanding thread
+  pthread_t cryo_tauhk_command_thread;
+  struct socketData cryo_tauhk_command_socket;
+  if (SouthIAm) {
+    populateSocketData(CRYO_HK_CMD_IP, CRYO_HK_CMD_PORT_FC2, &cryo_tauhk_command_socket);
+  } else {
+    populateSocketData(CRYO_HK_CMD_IP, CRYO_HK_CMD_PORT_FC1, &cryo_tauhk_command_socket);
+  }
+  pthread_create(&cryo_tauhk_command_thread, NULL, send_cryo_commands, (void *) &cryo_tauhk_command_socket);
 
   // new star cam stuff
   // command setup

--- a/mcp/rfsoc/rfsoc_commanding.c
+++ b/mcp/rfsoc/rfsoc_commanding.c
@@ -37,7 +37,7 @@
  * @param packet packet that I want to fill and 
  * @param commands pointer to the correct rfsoc commands substructure in commanddata (set by thread)
  */
-void generate_command_packet(struct rfsoc_data* packet, rfsoc_commands_t* commands) {
+void generate_rfsoc_command_packet(struct rfsoc_data* packet, rfsoc_commands_t* commands) {
     packet->incharge = InCharge;
     packet->drone_num = commands->drone;
     packet->command_num = commands->command;
@@ -46,7 +46,7 @@ void generate_command_packet(struct rfsoc_data* packet, rfsoc_commands_t* comman
     packet->param3 = commands->param3;
     packet->param4 = commands->param4;
     packet->param5 = commands->param5;
-    reset_command_packet(commands);
+    reset_rfsoc_command_packet(commands);
 };
 
 /**
@@ -54,7 +54,7 @@ void generate_command_packet(struct rfsoc_data* packet, rfsoc_commands_t* comman
  * 
  * @param packet packet to reset to 0
  */
-void reset_command_packet(struct rfsoc_data* packet) {
+void reset_rfsoc_command_packet(struct rfsoc_data* packet) {
     memset(packet, 0, sizeof(*packet));
 }
 
@@ -83,7 +83,7 @@ int which_command_thread(struct socketData* target) {
  * the rfsoc commanding information
  * @return int 
  */
-int check_command_ready(rfsoc_commands_t* commands) {
+int check_rfsoc_command_ready(rfsoc_commands_t* commands) {
     if (commands->command_ready == 1) {
         commands->command_ready = 0;
         return 1;
@@ -150,18 +150,18 @@ void * send_rfsoc_commands(void* args) {
         // first time setup of the socket is done
         }
         if (which_command_thread(socket_target) == 1) {
-            packet_status = check_command_ready(command_pointer1);
+            packet_status = check_rfsoc_command_ready(command_pointer1);
             if (packet_status == 1) {
                 blast_info("Got an RFSOC packet going into send!\n");
             }
         } else if (which_command_thread(socket_target) == 2) {
-            packet_status = check_command_ready(command_pointer2);
+            packet_status = check_rfsoc_command_ready(command_pointer2);
         }
         if (packet_status) {
             if (which_command_thread(socket_target) == 1) {
-                generate_command_packet(&rfsoc_packet, command_pointer1);
+                generate_rfsoc_command_packet(&rfsoc_packet, command_pointer1);
             } else if (which_command_thread(socket_target) == 2) {
-                generate_command_packet(&rfsoc_packet, command_pointer2);
+                generate_rfsoc_command_packet(&rfsoc_packet, command_pointer2);
             }
             if (!strcmp(socket_target->ipAddr, ipAddr)) {
                 packet_status = 0;


### PR DESCRIPTION
#144 and `tauhk-agent`: https://github.com/tim-balloon/tauHK-for-TIM/pull/1 set up MCP receiving data from TauHK. Here, I copy from @ianlowe13's RFSoC commanding setup in #147 to set up MCP sending UDP commands to a to-be-built receiver daemon on `tauhk-agent` side. Complements https://github.com/tim-balloon/tauHK-for-TIM/pull/2, which is starting to build this commanding, PID, and fridge-cycle infrastructure. 

I have tested that this produces the new commands under "Cryo Control" in COW as expected, and I can receive UDP packets with the right information on the flight Pi that will run the `tauhk-agent` code. 

WIP to make this agent talk to the Taurus crate, and confirm the full end-to-end command journey from COW->blastcmd->mcp commanding->cryo_tauhk_cmd.c->Pi via UDP->crate via protobuf->back to mcp in data stream->groundhog->kst.